### PR TITLE
Trace gossipsub scores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -148,7 +148,6 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,go,goland+all,git
 
-kinesis
 *.sh
 *.txt
 .vscode

--- a/.gitignore
+++ b/.gitignore
@@ -148,4 +148,8 @@ fabric.properties
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,go,goland+all,git
 
-./hermes
+kinesis
+*.sh
+*.txt
+.vscode
+*/venv

--- a/cmd/hermes/cmd_eth.go
+++ b/cmd/hermes/cmd_eth.go
@@ -185,7 +185,7 @@ func cmdEthAction(c *cli.Context) error {
 	genesisRoot := genConfig.GenesisValidatorRoot
 	genesisTime := genConfig.GenesisTime
 
-	// Temp
+	// compute fork version and fork digest
 	currentSlot := slots.Since(genesisTime)
 	currentEpoch := slots.ToEpoch(currentSlot)
 
@@ -193,10 +193,8 @@ func cmdEthAction(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("compute fork version for epoch %d: %w", currentEpoch, err)
 	}
-	// END Temp
 
 	forkDigest, err := signing.ComputeForkDigest(currentForkVersion[:], genesisRoot)
-	fmt.Println(ethConfig.Chain, hex.EncodeToString(forkDigest[:]))
 	if err != nil {
 		return fmt.Errorf("create fork digest (%s, %x): %w", genesisTime, genesisRoot, err)
 	}

--- a/cmd/hermes/cmd_eth.go
+++ b/cmd/hermes/cmd_eth.go
@@ -24,7 +24,7 @@ var ethConfig = &struct {
 	Devp2pPort                  int
 	Libp2pHost                  string
 	Libp2pPort                  int
-	Libp2pPeerscoreSnapshopFreq int // seconds
+	Libp2pPeerscoreSnapshotFreq time.Duration
 	PrysmHost                   string
 	PrysmPortHTTP               int
 	PrysmPortGRPC               int
@@ -39,7 +39,7 @@ var ethConfig = &struct {
 	Devp2pPort:                  0,
 	Libp2pHost:                  "127.0.0.1",
 	Libp2pPort:                  0,
-	Libp2pPeerscoreSnapshopFreq: 5,
+	Libp2pPeerscoreSnapshotFreq: 5 * time.Second,
 	PrysmHost:                   "",
 	PrysmPortHTTP:               3500, // default -> https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip
 	PrysmPortGRPC:               4000, // default -> https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip
@@ -129,12 +129,12 @@ var cmdEthFlags = []cli.Flag{
 		Destination: &ethConfig.Libp2pPort,
 		DefaultText: "random",
 	},
-	&cli.IntFlag{
+	&cli.DurationFlag{
 		Name:        "libp2p.peerscore.snapshot.frequency",
 		EnvVars:     []string{"HERMES_ETH_LIBP2P_PEERSCORE_SNAPSHOT_FREQUENCY"},
 		Usage:       "Frequency at which GossipSub peerscores will be accessed (in seconds)",
-		Value:       ethConfig.Libp2pPeerscoreSnapshopFreq,
-		Destination: &ethConfig.Libp2pPeerscoreSnapshopFreq,
+		Value:       ethConfig.Libp2pPeerscoreSnapshotFreq,
+		Destination: &ethConfig.Libp2pPeerscoreSnapshotFreq,
 		DefaultText: "random",
 	},
 	&cli.StringFlag{
@@ -204,7 +204,7 @@ func cmdEthAction(c *cli.Context) error {
 		Devp2pPort:                  ethConfig.Devp2pPort,
 		Libp2pHost:                  ethConfig.Libp2pHost,
 		Libp2pPort:                  ethConfig.Libp2pPort,
-		Libp2pPeerscoreSnapshopFreq: time.Duration(ethConfig.Libp2pPeerscoreSnapshopFreq) * time.Second,
+		Libp2pPeerscoreSnapshotFreq: ethConfig.Libp2pPeerscoreSnapshotFreq,
 		PrysmHost:                   ethConfig.PrysmHost,
 		PrysmPortHTTP:               ethConfig.PrysmPortHTTP,
 		PrysmPortGRPC:               ethConfig.PrysmPortGRPC,

--- a/cmd/hermes/cmd_eth.go
+++ b/cmd/hermes/cmd_eth.go
@@ -41,7 +41,7 @@ var ethConfig = &struct {
 	Devp2pPort:                  0,
 	Libp2pHost:                  "127.0.0.1",
 	Libp2pPort:                  0,
-	Libp2pPeerscoreSnapshotFreq: 5 * time.Second,
+	Libp2pPeerscoreSnapshotFreq: 60 * time.Second,
 	PrysmHost:                   "",
 	PrysmPortHTTP:               3500, // default -> https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip
 	PrysmPortGRPC:               4000, // default -> https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip

--- a/eth/genesis.go
+++ b/eth/genesis.go
@@ -23,15 +23,18 @@ var (
 	BellatrixForkVersion ForkVersion
 	CapellaForkVersion   ForkVersion
 	DenebForkVersion     ForkVersion
+
+	currentBeaconConfig = params.MainnetConfig() // init with Mainnet (we would override if needed)
 )
 
 // configure global ForkVersion variables
-func initNetworkForkVersions(network *params.BeaconChainConfig) {
-	Phase0ForkVersion = ForkVersion(network.GenesisForkVersion)
-	AltairForkVersion = ForkVersion(network.AltairForkVersion)
-	BellatrixForkVersion = ForkVersion(network.BellatrixForkVersion)
-	CapellaForkVersion = ForkVersion(network.CapellaForkVersion)
-	DenebForkVersion = ForkVersion(network.DenebForkVersion)
+func initNetworkForkVersions(beaconConfig *params.BeaconChainConfig) {
+	Phase0ForkVersion = ForkVersion(beaconConfig.GenesisForkVersion)
+	AltairForkVersion = ForkVersion(beaconConfig.AltairForkVersion)
+	BellatrixForkVersion = ForkVersion(beaconConfig.BellatrixForkVersion)
+	CapellaForkVersion = ForkVersion(beaconConfig.CapellaForkVersion)
+	DenebForkVersion = ForkVersion(beaconConfig.DenebForkVersion)
+	currentBeaconConfig = beaconConfig
 }
 
 // GenesisConfig represents the Genesis configuration with the Merkle Root

--- a/eth/genesis.go
+++ b/eth/genesis.go
@@ -6,7 +6,33 @@ import (
 	"time"
 
 	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 )
+
+// list of ForkVersions
+// 1st byte trick
+type ForkVersion [4]byte
+
+func (fv ForkVersion) String() string {
+	return hex.EncodeToString([]byte(fv[:]))
+}
+
+var (
+	Phase0ForkVersion    ForkVersion
+	AltairForkVersion    ForkVersion
+	BellatrixForkVersion ForkVersion
+	CapellaForkVersion   ForkVersion
+	DenebForkVersion     ForkVersion
+)
+
+// configure global ForkVersion variables
+func initNetworkForkVersions(network *params.BeaconChainConfig) {
+	Phase0ForkVersion = ForkVersion(network.GenesisForkVersion)
+	AltairForkVersion = ForkVersion(network.AltairForkVersion)
+	BellatrixForkVersion = ForkVersion(network.BellatrixForkVersion)
+	CapellaForkVersion = ForkVersion(network.CapellaForkVersion)
+	DenebForkVersion = ForkVersion(network.DenebForkVersion)
+}
 
 // GenesisConfig represents the Genesis configuration with the Merkle Root
 // at Genesis and the Time at Genesis.
@@ -57,4 +83,26 @@ func hexToBytes(s string) []byte {
 		panic(err)
 	}
 	return data
+}
+
+func GetCurrentForkVersion(epoch primitives.Epoch, beaconConfg *params.BeaconChainConfig) ([4]byte, error) {
+	switch {
+	case epoch < beaconConfg.AltairForkEpoch:
+		return [4]byte(beaconConfg.GenesisForkVersion), nil
+
+	case epoch < beaconConfg.BellatrixForkEpoch:
+		return [4]byte(beaconConfg.AltairForkVersion), nil
+
+	case epoch < beaconConfg.CapellaForkEpoch:
+		return [4]byte(beaconConfg.BellatrixForkVersion), nil
+
+	case epoch < beaconConfg.DenebForkEpoch:
+		return [4]byte(beaconConfg.CapellaForkVersion), nil
+
+	case epoch >= beaconConfg.DenebForkEpoch:
+		return [4]byte(beaconConfg.DenebForkVersion), nil
+
+	default:
+		return [4]byte{}, fmt.Errorf("not recognized case for epoch %d", epoch)
+	}
 }

--- a/eth/node.go
+++ b/eth/node.go
@@ -186,6 +186,16 @@ func NewNode(cfg *NodeConfig) (*Node, error) {
 	if err != nil {
 		return nil, fmt.Errorf("new prysm client")
 	}
+	// check if Prysm is valid
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	onNetwork, err := pryClient.isOnNetwork(ctx, cfg.ForkDigest)
+	if err != nil {
+		return nil, fmt.Errorf("prysm client: %w", err)
+	}
+	if !onNetwork {
+		return nil, fmt.Errorf("prysm client not in correct fork_digest")
+	}
 
 	// finally, initialize hermes node
 	n := &Node{

--- a/eth/node.go
+++ b/eth/node.go
@@ -346,8 +346,14 @@ func (n *Node) Start(ctx context.Context) error {
 		return fmt.Errorf("register RPC handlers: %w", err)
 	}
 
+	// get chain parameters for scores
+	actVals, err := n.pryClient.getActiveValidatorCount(ctx)
+	if err != nil {
+		return fmt.Errorf("fetch active validators: %w", err)
+	}
+
 	// initialize GossipSub
-	n.pubSub.gs, err = n.host.InitGossipSub(ctx, n.cfg.pubsubOptions(n)...)
+	n.pubSub.gs, err = n.host.InitGossipSub(ctx, n.cfg.pubsubOptions(n, actVals)...)
 	if err != nil {
 		return fmt.Errorf("init gossip sub: %w", err)
 	}

--- a/eth/node.go
+++ b/eth/node.go
@@ -110,9 +110,10 @@ func NewNode(cfg *NodeConfig) (*Node, error) {
 	}
 
 	hostCfg := &host.Config{
-		DataStream: ds,
-		Tracer:     cfg.Tracer,
-		Meter:      cfg.Meter,
+		DataStream:            ds,
+		PeerscoreSnapshotFreq: cfg.Libp2pPeerscoreSnapshotFreq,
+		Tracer:                cfg.Tracer,
+		Meter:                 cfg.Meter,
 	}
 
 	// initialize libp2p host

--- a/eth/node.go
+++ b/eth/node.go
@@ -8,10 +8,12 @@ import (
 	"sort"
 	"time"
 
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
 	gk "github.com/dennis-tra/go-kinesis"
 	"github.com/libp2p/go-libp2p/core/peer"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/thejerf/suture/v4"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
 	"github.com/probe-lab/hermes/host"
@@ -75,40 +77,39 @@ func NewNode(cfg *NodeConfig) (*Node, error) {
 	initNetworkForkVersions(cfg.BeaconConfig)
 
 	var ds host.DataStream
-	ds = host.NoopDataStream{}
-	// if cfg.AWSConfig != nil {
+	if cfg.AWSConfig != nil {
 
-	// 	droppedTraces, err := cfg.Meter.Int64Counter("dropped_traces")
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("new dropped_traces counter: %w", err)
-	// 	}
+		droppedTraces, err := cfg.Meter.Int64Counter("dropped_traces")
+		if err != nil {
+			return nil, fmt.Errorf("new dropped_traces counter: %w", err)
+		}
 
-	// 	notifiee := &gk.NotifieeBundle{
-	// 		DroppedRecordF: func(ctx context.Context, record gk.Record) {
-	// 			tevt, ok := record.(*host.TraceEvent)
-	// 			if !ok {
-	// 				droppedTraces.Add(ctx, 1, metric.WithAttributes(attribute.String("evt_type", "UNKNOWN")))
-	// 			} else {
-	// 				droppedTraces.Add(ctx, 1, metric.WithAttributes(attribute.String("evt_type", tevt.Type)))
-	// 			}
-	// 			slog.Warn("Dropped record", "partition_key", record.PartitionKey(), "size", len(record.Data()))
-	// 		},
-	// 	}
+		notifiee := &gk.NotifieeBundle{
+			DroppedRecordF: func(ctx context.Context, record gk.Record) {
+				tevt, ok := record.(*host.TraceEvent)
+				if !ok {
+					droppedTraces.Add(ctx, 1, metric.WithAttributes(attribute.String("evt_type", "UNKNOWN")))
+				} else {
+					droppedTraces.Add(ctx, 1, metric.WithAttributes(attribute.String("evt_type", tevt.Type)))
+				}
+				slog.Warn("Dropped record", "partition_key", record.PartitionKey(), "size", len(record.Data()))
+			},
+		}
 
-	// 	pcfg := gk.DefaultProducerConfig()
-	// 	pcfg.Log = slog.Default()
-	// 	pcfg.Meter = cfg.Meter
-	// 	pcfg.Notifiee = notifiee
-	// 	pcfg.RetryLimit = 5
+		pcfg := gk.DefaultProducerConfig()
+		pcfg.Log = slog.Default()
+		pcfg.Meter = cfg.Meter
+		pcfg.Notifiee = notifiee
+		pcfg.RetryLimit = 5
 
-	// 	p, err := gk.NewProducer(kinesis.NewFromConfig(*cfg.AWSConfig), cfg.KinesisStream, pcfg)
-	// 	if err != nil {
-	// 		return nil, fmt.Errorf("new kinesis producer: %w", err)
-	// 	}
-	// 	ds = p
-	// } else {
-	// 	ds = host.NoopDataStream{}
-	// }
+		p, err := gk.NewProducer(kinesis.NewFromConfig(*cfg.AWSConfig), cfg.KinesisStream, pcfg)
+		if err != nil {
+			return nil, fmt.Errorf("new kinesis producer: %w", err)
+		}
+		ds = p
+	} else {
+		ds = host.NoopDataStream{}
+	}
 
 	hostCfg := &host.Config{
 		DataStream:            ds,

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -401,7 +401,7 @@ func (n *NodeConfig) getDesiredFullTopics(encoder encoder.NetworkEncoding) []str
 	for idx, topicBase := range desiredTopics {
 		topicFormat, err := topicFormatFromBase(topicBase)
 		if err != nil {
-			slog.Warn("invalid gossipsub topic", topicBase)
+			slog.Warn("invalid gossipsub topic", slog.Attr{Key: "topic", Value: slog.StringValue(topicBase)})
 			continue
 		}
 		fullTopics[idx] = n.composeEthTopic(topicFormat, encoder)

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -23,6 +23,7 @@ import (
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	"github.com/libp2p/go-libp2p/p2p/transport/tcp"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/encoder"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
@@ -42,7 +43,8 @@ type NodeConfig struct {
 	BeaconConfig *params.BeaconChainConfig
 
 	// The fork digest of the network Hermes participates in
-	ForkDigest [4]byte
+	ForkDigest  [4]byte
+	ForkVersion ForkVersion
 
 	// The private key for the libp2p host and local enode in hex format
 	PrivateKeyStr string
@@ -63,6 +65,10 @@ type NodeConfig struct {
 	Libp2pHost                  string
 	Libp2pPort                  int
 	Libp2pPeerscoreSnapshotFreq time.Duration
+
+	// Message encoders
+	GossipSubMessageEncoder encoder.NetworkEncoding
+	RPCEncoder              encoder.NetworkEncoding
 
 	// The address information where the Beacon API or Prysm's custom API is accessible at
 	PrysmHost     string
@@ -294,6 +300,9 @@ func (n *NodeConfig) pubsubOptions(subFilter pubsub.SubscriptionFilter) []pubsub
 }
 
 const (
+	// Chain consta699576nts
+	slotsPerEpoch  = 32
+	secondsPerSlot = 12
 
 	// decayToZero specifies the terminal value that we will use when decaying
 	// a value.

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -62,7 +62,7 @@ type NodeConfig struct {
 	// The address information of the local libp2p host
 	Libp2pHost                  string
 	Libp2pPort                  int
-	Libp2pPeerscoreSnapshopFreq time.Duration
+	Libp2pPeerscoreSnapshotFreq time.Duration
 
 	// The address information where the Beacon API or Prysm's custom API is accessible at
 	PrysmHost     string
@@ -135,8 +135,8 @@ func (n *NodeConfig) Validate() error {
 		return fmt.Errorf("libp2p port must be greater than or equal to 0, got %d", n.Devp2pPort)
 	}
 
-	if n.Libp2pPeerscoreSnapshopFreq < 0 {
-		return fmt.Errorf("libp2p peerscore snapshop fequency must be greater than or equal to 0, got %d", n.Libp2pPeerscoreSnapshopFreq)
+	if n.Libp2pPeerscoreSnapshotFreq < 0 {
+		return fmt.Errorf("libp2p peerscore snapshop fequency must be positive")
 	}
 
 	if n.PrysmPortHTTP < 0 {

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -15,7 +15,7 @@ import (
 	gcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/libp2p/go-libp2p"
 	mplex "github.com/libp2p/go-libp2p-mplex"
-	"github.com/libp2p/go-libp2p-pubsub"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	pubsubpb "github.com/libp2p/go-libp2p-pubsub/pb"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -60,8 +60,9 @@ type NodeConfig struct {
 	Devp2pPort int
 
 	// The address information of the local libp2p host
-	Libp2pHost string
-	Libp2pPort int
+	Libp2pHost                  string
+	Libp2pPort                  int
+	Libp2pPeerscoreSnapshopFreq time.Duration
 
 	// The address information where the Beacon API or Prysm's custom API is accessible at
 	PrysmHost     string
@@ -132,6 +133,10 @@ func (n *NodeConfig) Validate() error {
 
 	if n.Libp2pPort < 0 {
 		return fmt.Errorf("libp2p port must be greater than or equal to 0, got %d", n.Devp2pPort)
+	}
+
+	if n.Libp2pPeerscoreSnapshopFreq < 0 {
+		return fmt.Errorf("libp2p peerscore snapshop fequency must be greater than or equal to 0, got %d", n.Libp2pPeerscoreSnapshopFreq)
 	}
 
 	if n.PrysmPortHTTP < 0 {

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -376,14 +376,14 @@ func desiredPubSubBaseTopics() []string {
 	return []string{
 		p2p.GossipBlockMessage,
 		p2p.GossipAggregateAndProofMessage,
-		p2p.GossipAttestationMessage,
+		// p2p.GossipAttestationMessage,
 		p2p.GossipExitMessage,
 		p2p.GossipAttesterSlashingMessage,
 		p2p.GossipProposerSlashingMessage,
 		p2p.GossipContributionAndProofMessage,
-		p2p.GossipSyncCommitteeMessage,
+		// p2p.GossipSyncCommitteeMessage,
 		p2p.GossipBlsToExecutionChangeMessage,
-		p2p.GossipBlobSidecarMessage,
+		// p2p.GossipBlobSidecarMessage,
 	}
 }
 

--- a/eth/node_notifiee.go
+++ b/eth/node_notifiee.go
@@ -84,7 +84,7 @@ func (n *Node) handleNewConnection(pid peer.ID) {
 	valid := true
 	ps := n.host.Peerstore()
 
-	_, err := n.reqResp.Status(ctx, pid)
+	st, err := n.reqResp.Status(ctx, pid)
 	if err != nil {
 		valid = false
 	} else {
@@ -104,7 +104,7 @@ func (n *Node) handleNewConnection(pid peer.ID) {
 					slog.Warn("Failed to store handshaked marker in peerstore", tele.LogAttrError(err))
 				}
 
-				slog.Info("Performed successful handshake", tele.LogAttrPeerID(pid), "seq", md.SeqNumber, "attnets", hex.EncodeToString(md.Attnets.Bytes()), "agent", av)
+				slog.Info("Performed successful handshake", tele.LogAttrPeerID(pid), "seq", md.SeqNumber, "attnets", hex.EncodeToString(md.Attnets.Bytes()), "agent", av, "fork-digest", hex.EncodeToString(st.ForkDigest))
 			}
 		}
 	}

--- a/eth/prysm.go
+++ b/eth/prysm.go
@@ -283,3 +283,20 @@ func (p *PrysmClient) Identity(ctx context.Context) (addrInfo *peer.AddrInfo, er
 
 	return addrInfo, nil
 }
+
+func (p *PrysmClient) getActiveValidatorCount(ctx context.Context) (activeVals uint64, err error) {
+	ctx, span := p.tracer.Start(ctx, "prysm_client.active_validators")
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+			span.RecordError(err)
+		}
+		span.End()
+	}()
+	actVals, err := p.beaconClient.ListValidators(ctx, &eth.ListValidatorsRequest{Active: true})
+	if err != nil {
+		return 0, err
+	}
+	activeVals = uint64(actVals.GetTotalSize())
+	return activeVals, nil
+}

--- a/eth/pubsub.go
+++ b/eth/pubsub.go
@@ -20,7 +20,7 @@ import (
 )
 
 type PubSubConfig struct {
-	ForkDigest     [4]byte
+	ForkVersion    ForkVersion
 	Encoder        encoder.NetworkEncoding
 	SecondsPerSlot time.Duration
 	GenesisTime    time.Time

--- a/eth/pubsub.go
+++ b/eth/pubsub.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
@@ -12,7 +13,8 @@ import (
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p/encoder"
-	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
+	ethtypes "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/thejerf/suture/v4"
 
 	"github.com/probe-lab/hermes/host"
@@ -20,6 +22,7 @@ import (
 )
 
 type PubSubConfig struct {
+	Topics         []string
 	ForkVersion    ForkVersion
 	Encoder        encoder.NetworkEncoding
 	SecondsPerSlot time.Duration
@@ -71,28 +74,17 @@ func (p *PubSub) Serve(ctx context.Context) error {
 		return fmt.Errorf("node's pubsub service uninitialized gossip sub: %w", suture.ErrTerminateSupervisorTree)
 	}
 
-	topicHandlers := map[string]host.TopicHandler{
-		p2p.BlockSubnetTopicFormat:                    p.host.TracedTopicHandler(host.NoopHandler),
-		p2p.AggregateAndProofSubnetTopicFormat:        p.handleAggregateAndProof,
-		p2p.ExitSubnetTopicFormat:                     p.host.TracedTopicHandler(host.NoopHandler),
-		p2p.ProposerSlashingSubnetTopicFormat:         p.host.TracedTopicHandler(host.NoopHandler),
-		p2p.AttesterSlashingSubnetTopicFormat:         p.host.TracedTopicHandler(host.NoopHandler),
-		p2p.SyncContributionAndProofSubnetTopicFormat: p.host.TracedTopicHandler(host.NoopHandler),
-		p2p.BlsToExecutionChangeSubnetTopicFormat:     p.host.TracedTopicHandler(host.NoopHandler),
-		// p2p.AttestationSubnetTopicFormat:              p.host.TracedTopicHandler(host.NoopHandler),
-		// p2p.SyncCommitteeSubnetTopicFormat:            p.host.TracedTopicHandler(host.NoopHandler),
-		// p2p.BlobSubnetTopicFormat:                     p.host.TracedTopicHandler(host.NoopHandler),
-	}
-
 	supervisor := suture.NewSimple("pubsub")
 
-	for topicFormat, topicHandler := range topicHandlers {
-		topicName := fmt.Sprintf(topicFormat, p.cfg.ForkDigest) + p.cfg.Encoder.ProtocolSuffix()
+	for _, topicName := range p.cfg.Topics {
 		topic, err := p.gs.Join(topicName)
 		if err != nil {
 			return fmt.Errorf("join pubsub topic %s: %w", topicName, err)
 		}
 		defer logDeferErr(topic.Close, fmt.Sprintf("failed closing %s topic", topicName))
+
+		// get the handler for the specific topic
+		topicHandler := p.mapPubSubTopicWithHandlers(topicName)
 
 		sub, err := topic.Subscribe()
 		if err != nil {
@@ -112,6 +104,15 @@ func (p *PubSub) Serve(ctx context.Context) error {
 	return supervisor.Serve(ctx)
 }
 
+func (p *PubSub) mapPubSubTopicWithHandlers(topic string) host.TopicHandler {
+	switch {
+	case strings.Contains(topic, p2p.GossipBlockMessage):
+		return p.handleBeaconBlock
+	default:
+		return p.host.TracedTopicHandler(host.NoopHandler)
+	}
+}
+
 var _ pubsub.SubscriptionFilter = (*Node)(nil)
 
 // CanSubscribe originally returns true if the topic is of interest, and we could subscribe to it.
@@ -129,16 +130,17 @@ func (n *Node) FilterIncomingSubscriptions(id peer.ID, subs []*pubsubpb.RPC_SubO
 	return pubsub.FilterSubscriptions(subs, n.CanSubscribe), nil
 }
 
-func (p *PubSub) handleAggregateAndProof(ctx context.Context, msg *pubsub.Message) error {
-	sbb := eth.SignedBeaconBlock{}
-	if err := p.cfg.Encoder.DecodeGossip(msg.Data, &sbb); err != nil {
-		return fmt.Errorf("decode beacon block gossip message: %w", err)
+func (p *PubSub) handleBeaconBlock(ctx context.Context, msg *pubsub.Message) error {
+	genericBlock, err := p.getSignedBeaconBlockForForkDigest(msg.Data)
+	if err != nil {
+		return err
 	}
 
-	blockSlot := sbb.GetBlock().GetSlot()
+	slot := genericBlock.GetSlot()
+	ProposerIndex := genericBlock.GetProposerIndex()
 
 	now := time.Now()
-	slotStart := p.cfg.GenesisTime.Add(time.Duration(blockSlot) * p.cfg.SecondsPerSlot)
+	slotStart := p.cfg.GenesisTime.Add(time.Duration(slot) * p.cfg.SecondsPerSlot)
 
 	evt := &host.TraceEvent{
 		Type:      "HANDLE_MESSAGE",
@@ -150,8 +152,8 @@ func (p *PubSub) handleAggregateAndProof(ctx context.Context, msg *pubsub.Messag
 			"MsgSize":    len(msg.Data),
 			"Topic":      msg.GetTopic(),
 			"Seq":        msg.GetSeqno(),
-			"ValIdx":     sbb.GetBlock().GetProposerIndex(),
-			"Slot":       blockSlot,
+			"ValIdx":     ProposerIndex,
+			"Slot":       slot,
 			"TimeInSlot": now.Sub(slotStart).Seconds(),
 		},
 	}
@@ -161,4 +163,67 @@ func (p *PubSub) handleAggregateAndProof(ctx context.Context, msg *pubsub.Messag
 	}
 
 	return nil
+}
+
+type GenericSignedBeaconBlock interface {
+	GetBlock() GenericBeaconBlock
+}
+
+type GenericBeaconBlock interface {
+	GetSlot() primitives.Slot
+	GetProposerIndex() primitives.ValidatorIndex
+}
+
+func (p *PubSub) getSignedBeaconBlockForForkDigest(msgData []byte) (genericSbb GenericBeaconBlock, err error) {
+	// get the correct fork
+
+	switch p.cfg.ForkVersion {
+	case Phase0ForkVersion:
+		phase0Sbb := ethtypes.SignedBeaconBlock{}
+		err = p.cfg.Encoder.DecodeGossip(msgData, &phase0Sbb)
+		if err != nil {
+			return genericSbb, fmt.Errorf("decode beacon block gossip message: %w", err)
+		}
+		genericSbb = phase0Sbb.GetBlock()
+		return genericSbb, err
+
+	case AltairForkVersion:
+		altairSbb := ethtypes.SignedBeaconBlockAltair{}
+		err = p.cfg.Encoder.DecodeGossip(msgData, &altairSbb)
+		if err != nil {
+			return genericSbb, fmt.Errorf("decode beacon block gossip message: %w", err)
+		}
+		genericSbb = altairSbb.GetBlock()
+		return genericSbb, err
+
+	case BellatrixForkVersion:
+		BellatrixSbb := ethtypes.SignedBeaconBlockBellatrix{}
+		err = p.cfg.Encoder.DecodeGossip(msgData, &BellatrixSbb)
+		if err != nil {
+			return genericSbb, fmt.Errorf("decode beacon block gossip message: %w", err)
+		}
+		genericSbb = BellatrixSbb.GetBlock()
+		return genericSbb, err
+
+	case CapellaForkVersion:
+		capellaSbb := ethtypes.SignedBeaconBlockCapella{}
+		err = p.cfg.Encoder.DecodeGossip(msgData, &capellaSbb)
+		if err != nil {
+			return genericSbb, fmt.Errorf("decode beacon block gossip message: %w", err)
+		}
+		genericSbb = capellaSbb.GetBlock()
+		return genericSbb, err
+
+	case DenebForkVersion:
+		denebSbb := ethtypes.SignedBeaconBlockDeneb{}
+		err = p.cfg.Encoder.DecodeGossip(msgData, &denebSbb)
+		if err != nil {
+			return genericSbb, fmt.Errorf("decode beacon block gossip message: %w", err)
+		}
+		genericSbb = denebSbb.GetBlock()
+		return genericSbb, err
+
+	default:
+		return genericSbb, fmt.Errorf("non recognized fork-version: %d", p.cfg.ForkVersion[:])
+	}
 }

--- a/eth/topic_score_params.go
+++ b/eth/topic_score_params.go
@@ -1,0 +1,101 @@
+package eth
+
+import (
+	"log/slog"
+	"math"
+	"strings"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
+)
+
+// check Prysm implementation as reference: https://github.com/prysmaticlabs/prysm/blob/develop/beacon-chain/p2p/gossip_scoring_params.go#L63
+
+const (
+	// topic weights
+	beaconBlockWeight          = 0.8
+	aggregateWeight            = 0.5
+	syncContributionWeight     = 0.2
+	attestationTotalWeight     = 1
+	syncCommitteesTotalWeight  = 0.4
+	attesterSlashingWeight     = 0.05
+	proposerSlashingWeight     = 0.05
+	voluntaryExitWeight        = 0.05
+	blsToExecutionChangeWeight = 0.05
+
+	// mesh-related params
+	maxInMeshScore        = 10
+	maxFirstDeliveryScore = 40
+
+	dampeningFactor = 90
+)
+
+var (
+	invalidDecayPeriod = 50 * oneEpochDuration()
+)
+
+func topicToScoreParamsMapper(topic string) *pubsub.TopicScoreParams {
+	switch {
+	case strings.Contains(topic, p2p.GossipBlockMessage):
+		return defaultBlockTopicParams()
+		// TODO: extend this to more topics
+	default:
+		slog.Warn("unrecognized gossip-topic to apply peerscores", topic)
+		return defaultBlockTopicParams()
+	}
+}
+
+// defaultBlockTopicParams returns the Block-topic specific parameters that need to be given to the topic subscriber
+func defaultBlockTopicParams() *pubsub.TopicScoreParams {
+	decayEpoch := time.Duration(5)
+	blocksPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch)
+	meshWeight := -0.717
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     beaconBlockWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    1,
+		FirstMessageDeliveriesDecay:     scoreDecay(20 * oneEpochDuration()),
+		FirstMessageDeliveriesCap:       23,
+		MeshMessageDeliveriesWeight:     meshWeight,
+		MeshMessageDeliveriesDecay:      scoreDecay(decayEpoch * oneEpochDuration()),
+		MeshMessageDeliveriesCap:        float64(blocksPerEpoch * uint64(decayEpoch)),
+		MeshMessageDeliveriesThreshold:  float64(blocksPerEpoch*uint64(decayEpoch)) / 10,
+		MeshMessageDeliveriesWindow:     2 * time.Second,
+		MeshMessageDeliveriesActivation: 4 * oneEpochDuration(),
+		MeshFailurePenaltyWeight:        meshWeight,
+		MeshFailurePenaltyDecay:         scoreDecay(decayEpoch * oneEpochDuration()),
+		InvalidMessageDeliveriesWeight:  -140.4475,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+// utility functions
+
+func oneSlotDuration() time.Duration {
+	return time.Duration(secondsPerSlot) * time.Second
+}
+
+func oneEpochDuration() time.Duration {
+	return time.Duration(slotsPerEpoch) * oneSlotDuration()
+}
+
+// determines the decay rate from the provided time period till
+// the decayToZero value. Ex: ( 1 -> 0.01)
+func scoreDecay(totalDurationDecay time.Duration) float64 {
+	numOfTimes := totalDurationDecay / oneSlotDuration()
+	return math.Pow(decayToZero, 1/float64(numOfTimes))
+}
+
+// denotes the unit time in mesh for scoring tallying.
+func inMeshTime() time.Duration {
+	return 1 * oneSlotDuration()
+}
+
+// the cap for `inMesh` time scoring.
+func inMeshCap() float64 {
+	return float64((3600 * time.Second) / inMeshTime())
+}

--- a/eth/topic_score_params.go
+++ b/eth/topic_score_params.go
@@ -1,14 +1,15 @@
 package eth
 
 import (
+	"fmt"
 	"log/slog"
 	"math"
 	"strings"
 	"time"
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/probe-lab/hermes/tele"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/p2p"
-	"github.com/prysmaticlabs/prysm/v5/config/params"
 )
 
 // check Prysm implementation as reference: https://github.com/prysmaticlabs/prysm/blob/develop/beacon-chain/p2p/gossip_scoring_params.go#L63
@@ -29,28 +30,57 @@ const (
 	maxInMeshScore        = 10
 	maxFirstDeliveryScore = 40
 
-	// dampeningFactor = 90
+	dampeningFactor = 90
 )
 
 var (
+	oneHundredEpochs   = 100 * oneEpochDuration()
 	invalidDecayPeriod = 50 * oneEpochDuration()
 )
 
-func topicToScoreParamsMapper(topic string) *pubsub.TopicScoreParams {
+func topicToScoreParamsMapper(topic string, activeValidators uint64) *pubsub.TopicScoreParams {
 	switch {
 	case strings.Contains(topic, p2p.GossipBlockMessage):
 		return defaultBlockTopicParams()
-		// TODO: extend this to more topics
+
+	case strings.Contains(topic, p2p.GossipAggregateAndProofMessage):
+		return defaultAggregateTopicParams(activeValidators)
+
+	case strings.Contains(topic, p2p.GossipAttestationMessage):
+		return defaultAggregateSubnetTopicParams(activeValidators)
+
+	case strings.Contains(topic, p2p.GossipExitMessage):
+		return defaultVoluntaryExitTopicParams()
+
+	case strings.Contains(topic, p2p.GossipAttesterSlashingMessage):
+		return defaultAttesterSlashingTopicParams()
+
+	case strings.Contains(topic, p2p.GossipProposerSlashingMessage):
+		return defaultProposerSlashingTopicParams()
+
+	case strings.Contains(topic, p2p.GossipContributionAndProofMessage):
+		return defaultSyncContributionTopicParams()
+
+	case strings.Contains(topic, p2p.GossipSyncCommitteeMessage):
+		return defaultSyncSubnetTopicParams(activeValidators)
+
+	case strings.Contains(topic, p2p.GossipBlsToExecutionChangeMessage):
+		return defaultBlsToExecutionChangeTopicParams()
+
+	case strings.Contains(topic, p2p.GossipBlobSidecarMessage):
+		return defaultBlockTopicParams()
+
 	default:
 		slog.Warn("unrecognized gossip-topic to apply peerscores", slog.Attr{Key: "topic", Value: slog.StringValue(topic)})
-		return defaultBlockTopicParams()
+		// return empty parameters
+		return &pubsub.TopicScoreParams{}
 	}
 }
 
 // defaultBlockTopicParams returns the Block-topic specific parameters that need to be given to the topic subscriber
 func defaultBlockTopicParams() *pubsub.TopicScoreParams {
 	decayEpoch := time.Duration(5)
-	blocksPerEpoch := uint64(params.BeaconConfig().SlotsPerEpoch)
+	blocksPerEpoch := uint64(currentBeaconConfig.SlotsPerEpoch)
 	meshWeight := -0.717
 	return &pubsub.TopicScoreParams{
 		TopicWeight:                     beaconBlockWeight,
@@ -73,14 +103,299 @@ func defaultBlockTopicParams() *pubsub.TopicScoreParams {
 	}
 }
 
+// defaultAggregateAndProofTopicParams returns the aggregate-topic specific parameters that need to be given to the topic subscriber
+func defaultAggregateTopicParams(activeValidators uint64) *pubsub.TopicScoreParams {
+	// Determine the expected message rate for the particular gossip topic.
+	aggPerSlot := aggregatorsPerSlot(activeValidators)
+	firstMessageCap, err := decayLimit(scoreDecay(1*oneEpochDuration()), float64(aggPerSlot*2/gossipSubD))
+	if err != nil {
+		slog.Warn("skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	firstMessageWeight := maxFirstDeliveryScore / firstMessageCap
+	meshThreshold, err := decayThreshold(scoreDecay(1*oneEpochDuration()), float64(aggPerSlot)/dampeningFactor)
+	if err != nil {
+		slog.Warn("skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	meshWeight := -scoreByWeight(aggregateWeight, meshThreshold)
+	meshCap := 4 * meshThreshold
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     aggregateWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    firstMessageWeight,
+		FirstMessageDeliveriesDecay:     scoreDecay(1 * oneEpochDuration()),
+		FirstMessageDeliveriesCap:       firstMessageCap,
+		MeshMessageDeliveriesWeight:     meshWeight,
+		MeshMessageDeliveriesDecay:      scoreDecay(1 * oneEpochDuration()),
+		MeshMessageDeliveriesCap:        meshCap,
+		MeshMessageDeliveriesThreshold:  meshThreshold,
+		MeshMessageDeliveriesWindow:     2 * time.Second,
+		MeshMessageDeliveriesActivation: 1 * oneEpochDuration(),
+		MeshFailurePenaltyWeight:        meshWeight,
+		MeshFailurePenaltyDecay:         scoreDecay(1 * oneEpochDuration()),
+		InvalidMessageDeliveriesWeight:  -maxScore() / aggregateWeight,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+func defaultSyncContributionTopicParams() *pubsub.TopicScoreParams {
+	// Determine the expected message rate for the particular gossip topic.
+	aggPerSlot := currentBeaconConfig.SyncCommitteeSubnetCount * currentBeaconConfig.TargetAggregatorsPerSyncSubcommittee
+	firstMessageCap, err := decayLimit(scoreDecay(1*oneEpochDuration()), float64(aggPerSlot*2/gossipSubD))
+	if err != nil {
+		slog.Warn("skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	firstMessageWeight := maxFirstDeliveryScore / firstMessageCap
+	meshThreshold, err := decayThreshold(scoreDecay(1*oneEpochDuration()), float64(aggPerSlot)/dampeningFactor)
+	if err != nil {
+		slog.Warn("skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	meshWeight := -scoreByWeight(syncContributionWeight, meshThreshold)
+	meshCap := 4 * meshThreshold
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     syncContributionWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    firstMessageWeight,
+		FirstMessageDeliveriesDecay:     scoreDecay(1 * oneEpochDuration()),
+		FirstMessageDeliveriesCap:       firstMessageCap,
+		MeshMessageDeliveriesWeight:     meshWeight,
+		MeshMessageDeliveriesDecay:      scoreDecay(1 * oneEpochDuration()),
+		MeshMessageDeliveriesCap:        meshCap,
+		MeshMessageDeliveriesThreshold:  meshThreshold,
+		MeshMessageDeliveriesWindow:     2 * time.Second,
+		MeshMessageDeliveriesActivation: 1 * oneEpochDuration(),
+		MeshFailurePenaltyWeight:        meshWeight,
+		MeshFailurePenaltyDecay:         scoreDecay(1 * oneEpochDuration()),
+		InvalidMessageDeliveriesWeight:  -maxScore() / syncContributionWeight,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+func defaultAggregateSubnetTopicParams(activeValidators uint64) *pubsub.TopicScoreParams {
+	subnetCount := currentBeaconConfig.AttestationSubnetCount
+	// Get weight for each specific subnet.
+	topicWeight := attestationTotalWeight / float64(subnetCount)
+	subnetWeight := activeValidators / subnetCount
+	if subnetWeight == 0 {
+		slog.Warn("Subnet weight is 0, skipping initializing topic scoring")
+		return nil
+	}
+	// Determine the amount of validators expected in a subnet in a single slot.
+	numPerSlot := time.Duration(subnetWeight / uint64(currentBeaconConfig.SlotsPerEpoch))
+	if numPerSlot == 0 {
+		slog.Warn("numPerSlot is 0, skipping initializing topic scoring")
+		return nil
+	}
+	comsPerSlot := committeeCountPerSlot(activeValidators)
+	exceedsThreshold := comsPerSlot >= 2*subnetCount/uint64(currentBeaconConfig.SlotsPerEpoch)
+	firstDecay := time.Duration(1)
+	meshDecay := time.Duration(4)
+	if exceedsThreshold {
+		firstDecay = 4
+		meshDecay = 16
+	}
+	rate := numPerSlot * 2 / gossipSubD
+	if rate == 0 {
+		slog.Warn("rate is 0, skipping initializing topic scoring")
+		return nil
+	}
+	// Determine expected first deliveries based on the message rate.
+	firstMessageCap, err := decayLimit(scoreDecay(firstDecay*oneEpochDuration()), float64(rate))
+	if err != nil {
+		slog.Warn("skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	firstMessageWeight := maxFirstDeliveryScore / firstMessageCap
+	// Determine expected mesh deliveries based on message rate applied with a dampening factor.
+	meshThreshold, err := decayThreshold(scoreDecay(meshDecay*oneEpochDuration()), float64(numPerSlot)/dampeningFactor)
+	if err != nil {
+		slog.Warn("skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	meshWeight := -scoreByWeight(topicWeight, meshThreshold)
+	meshCap := 4 * meshThreshold
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     topicWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    firstMessageWeight,
+		FirstMessageDeliveriesDecay:     scoreDecay(firstDecay * oneEpochDuration()),
+		FirstMessageDeliveriesCap:       firstMessageCap,
+		MeshMessageDeliveriesWeight:     meshWeight,
+		MeshMessageDeliveriesDecay:      scoreDecay(meshDecay * oneEpochDuration()),
+		MeshMessageDeliveriesCap:        meshCap,
+		MeshMessageDeliveriesThreshold:  meshThreshold,
+		MeshMessageDeliveriesWindow:     2 * time.Second,
+		MeshMessageDeliveriesActivation: 1 * oneEpochDuration(),
+		MeshFailurePenaltyWeight:        meshWeight,
+		MeshFailurePenaltyDecay:         scoreDecay(meshDecay * oneEpochDuration()),
+		InvalidMessageDeliveriesWeight:  -maxScore() / topicWeight,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+func defaultSyncSubnetTopicParams(activeValidators uint64) *pubsub.TopicScoreParams {
+	subnetCount := currentBeaconConfig.SyncCommitteeSubnetCount
+	// Get weight for each specific subnet.
+	topicWeight := syncCommitteesTotalWeight / float64(subnetCount)
+	syncComSize := currentBeaconConfig.SyncCommitteeSize
+	// Set the max as the sync committee size
+	if activeValidators > syncComSize {
+		activeValidators = syncComSize
+	}
+	subnetWeight := activeValidators / subnetCount
+	if subnetWeight == 0 {
+		slog.Warn("Subnet weight is 0, skipping initializing topic scoring")
+		return nil
+	}
+	firstDecay := time.Duration(1)
+	meshDecay := time.Duration(4)
+
+	rate := subnetWeight * 2 / gossipSubD
+	if rate == 0 {
+		slog.Warn("rate is 0, skipping initializing topic scoring")
+		return nil
+	}
+	// Determine expected first deliveries based on the message rate.
+	firstMessageCap, err := decayLimit(scoreDecay(firstDecay*oneEpochDuration()), float64(rate))
+	if err != nil {
+		slog.Warn("Skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	firstMessageWeight := maxFirstDeliveryScore / firstMessageCap
+	// Determine expected mesh deliveries based on message rate applied with a dampening factor.
+	meshThreshold, err := decayThreshold(scoreDecay(meshDecay*oneEpochDuration()), float64(subnetWeight)/dampeningFactor)
+	if err != nil {
+		slog.Warn("Skipping initializing topic scoring", tele.LogAttrError(err))
+		return nil
+	}
+	meshWeight := -scoreByWeight(topicWeight, meshThreshold)
+	meshCap := 4 * meshThreshold
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     topicWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    firstMessageWeight,
+		FirstMessageDeliveriesDecay:     scoreDecay(firstDecay * oneEpochDuration()),
+		FirstMessageDeliveriesCap:       firstMessageCap,
+		MeshMessageDeliveriesWeight:     meshWeight,
+		MeshMessageDeliveriesDecay:      scoreDecay(meshDecay * oneEpochDuration()),
+		MeshMessageDeliveriesCap:        meshCap,
+		MeshMessageDeliveriesThreshold:  meshThreshold,
+		MeshMessageDeliveriesWindow:     2 * time.Second,
+		MeshMessageDeliveriesActivation: 1 * oneEpochDuration(),
+		MeshFailurePenaltyWeight:        meshWeight,
+		MeshFailurePenaltyDecay:         scoreDecay(meshDecay * oneEpochDuration()),
+		InvalidMessageDeliveriesWeight:  -maxScore() / topicWeight,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+func defaultAttesterSlashingTopicParams() *pubsub.TopicScoreParams {
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     attesterSlashingWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    36,
+		FirstMessageDeliveriesDecay:     scoreDecay(oneHundredEpochs),
+		FirstMessageDeliveriesCap:       1,
+		MeshMessageDeliveriesWeight:     0,
+		MeshMessageDeliveriesDecay:      0,
+		MeshMessageDeliveriesCap:        0,
+		MeshMessageDeliveriesThreshold:  0,
+		MeshMessageDeliveriesWindow:     0,
+		MeshMessageDeliveriesActivation: 0,
+		MeshFailurePenaltyWeight:        0,
+		MeshFailurePenaltyDecay:         0,
+		InvalidMessageDeliveriesWeight:  -2000,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+func defaultProposerSlashingTopicParams() *pubsub.TopicScoreParams {
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     proposerSlashingWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    36,
+		FirstMessageDeliveriesDecay:     scoreDecay(oneHundredEpochs),
+		FirstMessageDeliveriesCap:       1,
+		MeshMessageDeliveriesWeight:     0,
+		MeshMessageDeliveriesDecay:      0,
+		MeshMessageDeliveriesCap:        0,
+		MeshMessageDeliveriesThreshold:  0,
+		MeshMessageDeliveriesWindow:     0,
+		MeshMessageDeliveriesActivation: 0,
+		MeshFailurePenaltyWeight:        0,
+		MeshFailurePenaltyDecay:         0,
+		InvalidMessageDeliveriesWeight:  -2000,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+func defaultVoluntaryExitTopicParams() *pubsub.TopicScoreParams {
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     voluntaryExitWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    2,
+		FirstMessageDeliveriesDecay:     scoreDecay(oneHundredEpochs),
+		FirstMessageDeliveriesCap:       5,
+		MeshMessageDeliveriesWeight:     0,
+		MeshMessageDeliveriesDecay:      0,
+		MeshMessageDeliveriesCap:        0,
+		MeshMessageDeliveriesThreshold:  0,
+		MeshMessageDeliveriesWindow:     0,
+		MeshMessageDeliveriesActivation: 0,
+		MeshFailurePenaltyWeight:        0,
+		MeshFailurePenaltyDecay:         0,
+		InvalidMessageDeliveriesWeight:  -2000,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
+func defaultBlsToExecutionChangeTopicParams() *pubsub.TopicScoreParams {
+	return &pubsub.TopicScoreParams{
+		TopicWeight:                     blsToExecutionChangeWeight,
+		TimeInMeshWeight:                maxInMeshScore / inMeshCap(),
+		TimeInMeshQuantum:               inMeshTime(),
+		TimeInMeshCap:                   inMeshCap(),
+		FirstMessageDeliveriesWeight:    2,
+		FirstMessageDeliveriesDecay:     scoreDecay(oneHundredEpochs),
+		FirstMessageDeliveriesCap:       5,
+		MeshMessageDeliveriesWeight:     0,
+		MeshMessageDeliveriesDecay:      0,
+		MeshMessageDeliveriesCap:        0,
+		MeshMessageDeliveriesThreshold:  0,
+		MeshMessageDeliveriesWindow:     0,
+		MeshMessageDeliveriesActivation: 0,
+		MeshFailurePenaltyWeight:        0,
+		MeshFailurePenaltyDecay:         0,
+		InvalidMessageDeliveriesWeight:  -2000,
+		InvalidMessageDeliveriesDecay:   scoreDecay(invalidDecayPeriod),
+	}
+}
+
 // utility functions
 
 func oneSlotDuration() time.Duration {
-	return time.Duration(secondsPerSlot) * time.Second
+	return time.Duration(currentBeaconConfig.SecondsPerSlot) * time.Second
 }
 
 func oneEpochDuration() time.Duration {
-	return time.Duration(slotsPerEpoch) * oneSlotDuration()
+	return time.Duration(currentBeaconConfig.SlotsPerEpoch) * oneSlotDuration()
 }
 
 // determines the decay rate from the provided time period till
@@ -98,4 +413,61 @@ func inMeshTime() time.Duration {
 // the cap for `inMesh` time scoring.
 func inMeshCap() float64 {
 	return float64((3600 * time.Second) / inMeshTime())
+}
+
+// is used to determine the threshold from the decay limit with
+// a provided growth rate. This applies the decay rate to a computed limit.
+func decayThreshold(decayRate, rate float64) (float64, error) {
+	d, err := decayLimit(decayRate, rate)
+	if err != nil {
+		return 0, err
+	}
+	return d * decayRate, nil
+}
+
+// decayLimit provides the value till which a decay process will
+// limit till provided with an expected growth rate.
+func decayLimit(decayRate, rate float64) (float64, error) {
+	if 1 <= decayRate {
+		return 0, fmt.Errorf("got an invalid decayLimit rate: %f", decayRate)
+	}
+	return rate / (1 - decayRate), nil
+}
+
+// provides the relevant score by the provided weight and threshold.
+func scoreByWeight(weight, threshold float64) float64 {
+	return maxScore() / (weight * threshold * threshold)
+}
+
+// maxScore attainable by a peer.
+func maxScore() float64 {
+	totalWeight := beaconBlockWeight + aggregateWeight + syncContributionWeight +
+		attestationTotalWeight + syncCommitteesTotalWeight + attesterSlashingWeight +
+		proposerSlashingWeight + voluntaryExitWeight + blsToExecutionChangeWeight
+	return (maxInMeshScore + maxFirstDeliveryScore) * totalWeight
+}
+
+// Uses a very rough gauge for total aggregator size per slot.
+func aggregatorsPerSlot(activeValidators uint64) uint64 {
+	comms := committeeCountPerSlot(activeValidators)
+	totalAggs := comms * currentBeaconConfig.TargetAggregatorsPerCommittee
+	return totalAggs
+}
+
+func committeeCountPerSlot(activeValidators uint64) uint64 {
+	// Use a static parameter for now rather than a dynamic one, we can use
+	// the actual parameter later when we have figured out how to fix a circular
+	// dependency in service startup order.
+	return slotCommitteeCount(activeValidators)
+}
+
+func slotCommitteeCount(activeValidatorCount uint64) uint64 {
+	var committeesPerSlot = activeValidatorCount / currentBeaconConfig.SecondsPerSlot / currentBeaconConfig.TargetCommitteeSize
+	if committeesPerSlot > currentBeaconConfig.MaxCommitteesPerSlot {
+		return currentBeaconConfig.MaxCommitteesPerSlot
+	}
+	if committeesPerSlot == 0 {
+		return 1
+	}
+	return committeesPerSlot
 }

--- a/eth/topic_score_params.go
+++ b/eth/topic_score_params.go
@@ -29,7 +29,7 @@ const (
 	maxInMeshScore        = 10
 	maxFirstDeliveryScore = 40
 
-	dampeningFactor = 90
+	// dampeningFactor = 90
 )
 
 var (
@@ -42,7 +42,7 @@ func topicToScoreParamsMapper(topic string) *pubsub.TopicScoreParams {
 		return defaultBlockTopicParams()
 		// TODO: extend this to more topics
 	default:
-		slog.Warn("unrecognized gossip-topic to apply peerscores", topic)
+		slog.Warn("unrecognized gossip-topic to apply peerscores", slog.Attr{Key: "topic", Value: slog.StringValue(topic)})
 		return defaultBlockTopicParams()
 	}
 }

--- a/host/host.go
+++ b/host/host.go
@@ -3,7 +3,6 @@ package host
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
@@ -319,18 +318,12 @@ func (h *Host) UpdatePeerScore(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
 	// TODO: first guess -> this should be easier for the data-analysis later on
 	for pid, score := range scores {
 		// get the traceEvent from the raw score mapping
-		scoreEvent := composePeerScoreEventFromRawMap(pid, score)
-		jsonPayload, err := json.Marshal(scoreEvent)
-		if err != nil {
-			slog.Error("non jsoneable peerscore", tele.LogAttrError(err))
-			continue // do not trace events without payload :)
-		}
-
+		scoreData := composePeerScoreEventFromRawMap(pid, score)
 		trace := &TraceEvent{
 			Type:      PeerScoreEventType,
 			PeerID:    h.ID(),
 			Timestamp: t,
-			Payload:   jsonPayload,
+			Payload:   scoreData,
 		}
 
 		traceCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/host/host.go
+++ b/host/host.go
@@ -310,7 +310,7 @@ func (h *Host) UpdatePeerScore(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
 	// get the event time
 	t := time.Now()
 
-	slog.Debug("updating local peerscore - len:", tele.LogAttrPeerScoresLen(scores))
+	slog.Debug("updating local peerscore:", tele.LogAttrPeerScoresLen(scores))
 
 	// update local copy of the scores
 	h.sk.Update(scores)
@@ -322,7 +322,7 @@ func (h *Host) UpdatePeerScore(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
 		scoreEvent := composePeerScoreEventFromRawMap(pid, score)
 		jsonPayload, err := json.Marshal(scoreEvent)
 		if err != nil {
-			slog.Error("non jsoneable peerscore", slog.String("err", err.Error()))
+			slog.Error("non jsoneable peerscore", tele.LogAttrError(err))
 		}
 
 		trace := &TraceEvent{
@@ -332,7 +332,8 @@ func (h *Host) UpdatePeerScore(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
 			Payload:   jsonPayload,
 		}
 
-		traceCtx := context.Background()
+		traceCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		h.cfg.DataStream.PutRecord(traceCtx, trace)
 	}
 }

--- a/host/host.go
+++ b/host/host.go
@@ -3,15 +3,16 @@ package host
 import (
 	"context"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
 	"sync/atomic"
 	"time"
 
-	"github.com/hashicorp/golang-lru/v2"
+	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/libp2p/go-libp2p"
-	"github.com/libp2p/go-libp2p-pubsub"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/event"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
@@ -26,7 +27,8 @@ import (
 )
 
 type Config struct {
-	DataStream DataStream
+	DataStream            DataStream
+	PeerscoreSnapshopFreq time.Duration
 
 	// Telemetry accessors
 	Tracer trace.Tracer
@@ -38,6 +40,7 @@ type Host struct {
 	cfg   *Config
 	ps    *pubsub.PubSub
 	avlru *lru.Cache[string, string]
+	sk    *ScoreKeeper
 
 	meterSubmittedTraces metric.Int64Counter
 }
@@ -57,6 +60,7 @@ func New(cfg *Config, opts ...libp2p.Option) (*Host, error) {
 		Host:  h,
 		cfg:   cfg,
 		avlru: avlru,
+		sk:    newScoreKeeper(cfg.PeerscoreSnapshopFreq),
 	}
 
 	hermesHost.meterSubmittedTraces, err = cfg.Meter.Int64Counter("submitted_traces")
@@ -121,7 +125,12 @@ func (h *Host) InitGossipSub(ctx context.Context, opts ...pubsub.Option) (*pubsu
 		return nil, fmt.Errorf("new gossip sub meter tracer: %w", err)
 	}
 
-	opts = append(opts, pubsub.WithRawTracer(h), pubsub.WithRawTracer(mt), pubsub.WithEventTracer(h))
+	opts = append(
+		opts,
+		pubsub.WithRawTracer(h),
+		pubsub.WithRawTracer(mt),
+		pubsub.WithEventTracer(h),
+		pubsub.WithPeerScoreInspect(h.UpdatePeerScore, h.sk.freq))
 	ps, err := pubsub.NewGossipSub(ctx, h, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("new gossip sub: %w", err)
@@ -294,5 +303,36 @@ func MaddrFrom(ip string, port uint) (ma.Multiaddr, error) {
 		return ma.NewMultiaddr(fmt.Sprintf("/ip6/%s/tcp/%d", ip, port))
 	} else {
 		return nil, fmt.Errorf("invalid IP address: %s", ip)
+	}
+}
+
+func (h *Host) UpdatePeerScore(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
+	// get the event time
+	t := time.Now()
+
+	slog.Debug("updating local peerscore - len:", tele.LogAttrPeerScoresLen(scores))
+
+	// update local copy of the scores
+	h.sk.Update(scores)
+
+	// create and send a dedicated event per peer to the go-kinesis DataStream
+	// TODO: first guess -> this should be easier for the data-analysis later on
+	for pid, score := range scores {
+		// get the traceEvent from the raw score mapping
+		scoreEvent := composePeerScoreEventFromRawMap(pid, score)
+		jsonPayload, err := json.Marshal(scoreEvent)
+		if err != nil {
+			slog.Error("non jsoneable peerscore", slog.String("err", err.Error()))
+		}
+
+		trace := &TraceEvent{
+			Type:      PeerScoreEventType,
+			PeerID:    h.ID(),
+			Timestamp: t,
+			Payload:   jsonPayload,
+		}
+
+		traceCtx := context.Background()
+		h.cfg.DataStream.PutRecord(traceCtx, trace)
 	}
 }

--- a/host/host.go
+++ b/host/host.go
@@ -28,7 +28,7 @@ import (
 
 type Config struct {
 	DataStream            DataStream
-	PeerscoreSnapshopFreq time.Duration
+	PeerscoreSnapshotFreq time.Duration
 
 	// Telemetry accessors
 	Tracer trace.Tracer
@@ -60,7 +60,7 @@ func New(cfg *Config, opts ...libp2p.Option) (*Host, error) {
 		Host:  h,
 		cfg:   cfg,
 		avlru: avlru,
-		sk:    newScoreKeeper(cfg.PeerscoreSnapshopFreq),
+		sk:    newScoreKeeper(cfg.PeerscoreSnapshotFreq),
 	}
 
 	hermesHost.meterSubmittedTraces, err = cfg.Meter.Int64Counter("submitted_traces")
@@ -323,6 +323,7 @@ func (h *Host) UpdatePeerScore(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
 		jsonPayload, err := json.Marshal(scoreEvent)
 		if err != nil {
 			slog.Error("non jsoneable peerscore", tele.LogAttrError(err))
+			continue // do not trace events without payload :)
 		}
 
 		trace := &TraceEvent{

--- a/host/peerscore.go
+++ b/host/peerscore.go
@@ -25,24 +25,25 @@ type TraceEventPeerScore struct {
 	Topics             []TopicScore
 }
 
-func composePeerScoreEventFromRawMap(pid peer.ID, score *pubsub.PeerScoreSnapshot) TraceEventPeerScore {
-	topics := make([]TopicScore, len(score.Topics))
+func composePeerScoreEventFromRawMap(pid peer.ID, score *pubsub.PeerScoreSnapshot) map[string]any {
+	topics := make([]any, len(score.Topics))
 	for topic, snapshot := range score.Topics {
-		topics = append(topics, TopicScore{
-			Topic:                    topic,
-			TimeInMesh:               snapshot.TimeInMesh,
-			FirstMessageDeliveries:   snapshot.FirstMessageDeliveries,
-			MeshMessageDeliveries:    snapshot.MeshMessageDeliveries,
-			InvalidMessageDeliveries: snapshot.InvalidMessageDeliveries,
-		})
+		topicScore := map[string]any{
+			"Topic":                    topic,
+			"TimeInMesh":               snapshot.TimeInMesh,
+			"FirstMessageDeliveries":   snapshot.FirstMessageDeliveries,
+			"MeshMessageDeliveries":    snapshot.MeshMessageDeliveries,
+			"InvalidMessageDeliveries": snapshot.InvalidMessageDeliveries,
+		}
+		topics = append(topics, topicScore)
 	}
-	return TraceEventPeerScore{
-		PeerID:             pid.String(),
-		Score:              score.Score,
-		AppSpecificScore:   score.AppSpecificScore,
-		IPColocationFactor: score.IPColocationFactor,
-		BehaviourPenalty:   score.BehaviourPenalty,
-		Topics:             topics,
+	return map[string]any{
+		"PeerID":             pid.String(),
+		"Score":              score.Score,
+		"AppSpecificScore":   score.AppSpecificScore,
+		"IPColocationFactor": score.IPColocationFactor,
+		"BehaviourPenalty":   score.BehaviourPenalty,
+		"Topics":             topics,
 	}
 }
 

--- a/host/peerscore.go
+++ b/host/peerscore.go
@@ -9,24 +9,24 @@ import (
 )
 
 type TopicScore struct {
-	Topic                    string        `json:"topic"`
-	TimeInMesh               time.Duration `json:"timeInMesh"`
-	FirstMessageDeliveries   float64       `json:"firstMessageDeliveries"`
-	MeshMessageDeliveries    float64       `json:"meshMessageDeliveries"`
-	InvalidMessageDeliveries float64       `json:"invalidMessageDeliveries"`
+	Topic                    string
+	TimeInMesh               time.Duration
+	FirstMessageDeliveries   float64
+	MeshMessageDeliveries    float64
+	InvalidMessageDeliveries float64
 }
 
 type TraceEventPeerScore struct {
-	PeerID             string       `json:"peerID"`
-	Score              float64      `json:"score"`
-	AppSpecificScore   float64      `json:"appSpecificScore"`
-	IPColocationFactor float64      `json:"ipColocationFactor"`
-	BehaviourPenalty   float64      `json:"behaviourPenalty"`
-	Topics             []TopicScore `json:"topics"`
+	PeerID             string
+	Score              float64
+	AppSpecificScore   float64
+	IPColocationFactor float64
+	BehaviourPenalty   float64
+	Topics             []TopicScore
 }
 
 func composePeerScoreEventFromRawMap(pid peer.ID, score *pubsub.PeerScoreSnapshot) TraceEventPeerScore {
-	var topics []TopicScore
+	topics := make([]TopicScore, len(score.Topics))
 	for topic, snapshot := range score.Topics {
 		topics = append(topics, TopicScore{
 			Topic:                    topic,

--- a/host/peerscore.go
+++ b/host/peerscore.go
@@ -1,0 +1,76 @@
+package host
+
+import (
+	"sync"
+	"time"
+
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+type TopicScore struct {
+	Topic                    string        `json:"topic"`
+	TimeInMesh               time.Duration `json:"timeInMesh"`
+	FirstMessageDeliveries   float64       `json:"firstMessageDeliveries"`
+	MeshMessageDeliveries    float64       `json:"meshMessageDeliveries"`
+	InvalidMessageDeliveries float64       `json:"invalidMessageDeliveries"`
+}
+
+type TraceEventPeerScore struct {
+	PeerID             string       `json:"peerID"`
+	Score              float64      `json:"score"`
+	AppSpecificScore   float64      `json:"appSpecificScore"`
+	IPColocationFactor float64      `json:"ipColocationFactor"`
+	BehaviourPenalty   float64      `json:"behaviourPenalty"`
+	Topics             []TopicScore `json:"topics"`
+}
+
+func composePeerScoreEventFromRawMap(pid peer.ID, score *pubsub.PeerScoreSnapshot) TraceEventPeerScore {
+	var topics []TopicScore
+	for topic, snapshot := range score.Topics {
+		topics = append(topics, TopicScore{
+			Topic:                    topic,
+			TimeInMesh:               snapshot.TimeInMesh,
+			FirstMessageDeliveries:   snapshot.FirstMessageDeliveries,
+			MeshMessageDeliveries:    snapshot.MeshMessageDeliveries,
+			InvalidMessageDeliveries: snapshot.InvalidMessageDeliveries,
+		})
+	}
+	return TraceEventPeerScore{
+		PeerID:             pid.String(),
+		Score:              score.Score,
+		AppSpecificScore:   score.AppSpecificScore,
+		IPColocationFactor: score.IPColocationFactor,
+		BehaviourPenalty:   score.BehaviourPenalty,
+		Topics:             topics,
+	}
+}
+
+const PeerScoreEventType = "PEERSCORE"
+
+// ScoreKeeper is a thread-safe local copy of the score per peer and per copy
+// TODO: figure out if this is some sort of info that we want to expose through OpenTelemetry (Still good to have it)
+type ScoreKeeper struct {
+	lk     sync.Mutex
+	scores map[peer.ID]*pubsub.PeerScoreSnapshot
+	freq   time.Duration
+}
+
+func (sk *ScoreKeeper) Update(scores map[peer.ID]*pubsub.PeerScoreSnapshot) {
+	sk.lk.Lock()
+	sk.scores = scores
+	sk.lk.Unlock()
+}
+
+func (sk *ScoreKeeper) Get() map[peer.ID]*pubsub.PeerScoreSnapshot {
+	sk.lk.Lock()
+	defer sk.lk.Unlock()
+	return sk.scores
+}
+
+func newScoreKeeper(freq time.Duration) *ScoreKeeper {
+	return &ScoreKeeper{
+		freq:   freq,
+		scores: make(map[peer.ID]*pubsub.PeerScoreSnapshot),
+	}
+}

--- a/host/producer.go
+++ b/host/producer.go
@@ -2,8 +2,6 @@ package host
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 
 	gk "github.com/dennis-tra/go-kinesis"
 )
@@ -23,11 +21,5 @@ func (n NoopDataStream) Start(ctx context.Context) error {
 }
 
 func (n NoopDataStream) PutRecord(ctx context.Context, record gk.Record) error {
-	rec := record.(*TraceEvent)
-	bts, err := json.Marshal(rec)
-	if err != nil {
-		return fmt.Errorf("marshaling trace event to json: %w", err)
-	}
-	fmt.Println(string(bts))
 	return ctx.Err()
 }

--- a/host/producer.go
+++ b/host/producer.go
@@ -2,6 +2,8 @@ package host
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 
 	gk "github.com/dennis-tra/go-kinesis"
 )
@@ -21,5 +23,11 @@ func (n NoopDataStream) Start(ctx context.Context) error {
 }
 
 func (n NoopDataStream) PutRecord(ctx context.Context, record gk.Record) error {
+	rec := record.(*TraceEvent)
+	bts, err := json.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("marshaling trace event to json: %w", err)
+	}
+	fmt.Println(string(bts))
 	return ctx.Err()
 }

--- a/host/pubsub.go
+++ b/host/pubsub.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/libp2p/go-libp2p-pubsub"
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 

--- a/host/pubsub.go
+++ b/host/pubsub.go
@@ -8,6 +8,7 @@ import (
 
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/probe-lab/hermes/tele"
 )
 
 type TopicHandler = func(context.Context, *pubsub.Message) error
@@ -45,7 +46,8 @@ func (t *TopicSubscription) Serve(ctx context.Context) error {
 		}
 
 		if err := t.Handler(ctx, msg); err != nil {
-			return fmt.Errorf("handle gossip message for topic %s: %w", t.Sub.Topic(), err)
+			slog.Error("handle gossip message for", slog.Attr{Key: "topic", Value: slog.StringValue(t.Sub.Topic())}, tele.LogAttrError(err))
+			continue
 		}
 	}
 }

--- a/tele/log.go
+++ b/tele/log.go
@@ -3,13 +3,15 @@ package tele
 import (
 	"log/slog"
 
+	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-libp2p/core/peer"
 )
 
 // Attributes that can be used with logging or tracing
 const (
-	AttrKeyError  = "err"
-	AttrKeyPeerID = "peer_id"
+	AttrKeyError         = "err"
+	AttrKeyPeerID        = "peer_id"
+	AttrKeyPeerScoresLen = "peerscores_len"
 )
 
 func LogAttrError(err error) slog.Attr {
@@ -18,4 +20,8 @@ func LogAttrError(err error) slog.Attr {
 
 func LogAttrPeerID(pid peer.ID) slog.Attr {
 	return slog.String(AttrKeyPeerID, pid.String())
+}
+
+func LogAttrPeerScoresLen(scores map[peer.ID]*pubsub.PeerScoreSnapshot) slog.Attr {
+	return slog.Attr{Key: AttrKeyPeerScoresLen, Value: slog.AnyValue(len(scores))}
 }


### PR DESCRIPTION
# Decription
The current tracing module of the Libp2p host and the GossipSub events includes most of the interactions between `Hermes` and remote peers in the Ethereum network. There is still a relevant point missing to debug, with higher resolution, how GossipSub events (mostly `PRUNES`/`DISCONNECTIONS`) relate to the `PeerScore` of each peer per topic. 

Thus, this PR aims to aggregate the periodic export of the `PeerScores` snapshots. This feature was already present in the Lotus + TraceCatcher combo but hasn't landed on Hermes yet.  

# Tasks
- [x] Add the periodic inspection of the `PeerScores` (per peer and per topic), and flush them as traces
- [x] Allow the Snapshot Frequency to be adjustable (Let me know if you want a smaller name for the flag, I went for a descriptive one ;) )
- [x] Incorporate the new feature to the Ethereum GossipSub service as an Option
- [x] Test whether the `peerscore` traces are getting correctly flushed and tracked at the AWS kinesis instance 
