### PR TITLE
fix: disable 32bit tests

### DIFF
--- a/.github/workflows/go-test-config.json
+++ b/.github/workflows/go-test-config.json
@@ -1,0 +1,3 @@
+{
+  "skip32bit": true
+}


### PR DESCRIPTION
32bit arch tests are failing consistently on Linux and Windows, but passing on 64bit arch. Due to incompatible dependencies.

Disabling 32 bit testing