### PR TITLE
fix: go -> 1.22.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/probe-lab/hermes
 
-go 1.22
+go 1.22.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.0


### PR DESCRIPTION
Fixes error - 
```
go: downloading go1.22 (darwin/arm64)
go: download go1.22 for darwin/arm64: toolchain not available
```

Check this out - https://github.com/golang/go/issues/62278#issuecomment-1933790368