### PR TITLE
feat: Handle attestation messages

### DIFF
--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -376,7 +376,7 @@ func desiredPubSubBaseTopics() []string {
 	return []string{
 		p2p.GossipBlockMessage,
 		p2p.GossipAggregateAndProofMessage,
-		// p2p.GossipAttestationMessage,
+		p2p.GossipAttestationMessage,
 		p2p.GossipExitMessage,
 		p2p.GossipAttesterSlashingMessage,
 		p2p.GossipProposerSlashingMessage,
@@ -475,8 +475,9 @@ func (n *NodeConfig) getDefaultTopicScoreParams(encoder encoder.NetworkEncoding,
 	desiredTopics := n.getDesiredFullTopics(encoder)
 	topicScores := make(map[string]*pubsub.TopicScoreParams, len(desiredTopics))
 	for _, topic := range desiredTopics {
-		params := topicToScoreParamsMapper(topic, activeValidators)
-		topicScores[topic] = params
+		if params := topicToScoreParamsMapper(topic, activeValidators); params != nil {
+			topicScores[topic] = params
+		}
 	}
 	return topicScores
 }

--- a/eth/pubsub.go
+++ b/eth/pubsub.go
@@ -108,6 +108,8 @@ func (p *PubSub) mapPubSubTopicWithHandlers(topic string) host.TopicHandler {
 	switch {
 	case strings.Contains(topic, p2p.GossipBlockMessage):
 		return p.handleBeaconBlock
+	case strings.Contains(topic, p2p.GossipAttestationMessage):
+		return p.handleAttestation
 	default:
 		return p.host.TracedTopicHandler(host.NoopHandler)
 	}
@@ -157,6 +159,55 @@ func (p *PubSub) handleBeaconBlock(ctx context.Context, msg *pubsub.Message) err
 			"TimeInSlot": now.Sub(slotStart).Seconds(),
 		},
 	}
+
+	if err := p.cfg.DataStream.PutRecord(ctx, evt); err != nil {
+		slog.Warn("failed putting topic handler event", tele.LogAttrError(err))
+	}
+
+	return nil
+}
+
+func (p *PubSub) handleAttestation(ctx context.Context, msg *pubsub.Message) error {
+	if msg == nil || msg.Topic == nil || *msg.Topic == "" {
+		return fmt.Errorf("nil message or topic")
+	}
+
+	attestation := ethtypes.Attestation{}
+	err := p.cfg.Encoder.DecodeGossip(msg.Data, &attestation)
+	if err != nil {
+		return fmt.Errorf("decode attestation gossip message: %w", err)
+	}
+
+	now := time.Now()
+	evt := &host.TraceEvent{
+		Type:      "HANDLE_MESSAGE",
+		PeerID:    p.host.ID(),
+		Timestamp: now,
+		Payload: map[string]any{
+			"PeerID":          msg.ReceivedFrom.String(),
+			"MsgID":           hex.EncodeToString([]byte(msg.ID)),
+			"MsgSize":         len(msg.Data),
+			"Topic":           msg.GetTopic(),
+			"Seq":             msg.GetSeqno(),
+			"CommIdx":         attestation.GetData().GetCommitteeIndex(),
+			"Slot":            attestation.GetData().GetSlot(),
+			"BeaconBlockRoot": attestation.GetData().GetBeaconBlockRoot(),
+			"Source":          attestation.GetData().GetSource(),
+			"Target":          attestation.GetData().GetTarget(),
+		},
+	}
+	slog.Info(
+		"Handling attestation gossip message",
+		"PeerID", p.host.ID(),
+		"RemotePeerID", msg.ReceivedFrom.String(),
+		"MsgID", hex.EncodeToString([]byte(msg.ID)),
+		"MsgSize", len(msg.Data),
+		"Topic", msg.GetTopic(),
+		"Seq", msg.GetSeqno(),
+		"CommIdx", attestation.GetData().GetCommitteeIndex(),
+		"Slot", attestation.GetData().GetSlot(),
+		"BeaconBlockRoot", attestation.GetData().GetBeaconBlockRoot(),
+	)
 
 	if err := p.cfg.DataStream.PutRecord(ctx, evt); err != nil {
 		slog.Warn("failed putting topic handler event", tele.LogAttrError(err))


### PR DESCRIPTION
Add attestation topic handler to decode attestation p2p message and produce TraceEvent.

```
info  | 17:26:16.330068 | Handling attestation gossip message 
PeerID=16Uiu2HAm2ip3wstWCRT7bfagDUxfXM1KGy3HXu9r7cGnjCJGDS9x 
RemotePeerID=16Uiu2HAm1smC4eM6NQ8sN5m4AccRZuByFmbhU9WxV28rGmSQ6WJM 
MsgID=6d272729045ada8e5c0b79499bd916f99ae5f4fa 
MsgSize=226 
Topic=/eth2/d31f6191/beacon_attestation_7/ssz_snappy 
Seq=[] 
CommIdx=0 
Slot=5005031
```