### PR TITLE
feat: Handle sync committee message

### DIFF
--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -381,7 +381,7 @@ func desiredPubSubBaseTopics() []string {
 		p2p.GossipAttesterSlashingMessage,
 		p2p.GossipProposerSlashingMessage,
 		p2p.GossipContributionAndProofMessage,
-		// p2p.GossipSyncCommitteeMessage,
+		p2p.GossipSyncCommitteeMessage,
 		p2p.GossipBlsToExecutionChangeMessage,
 		// p2p.GossipBlobSidecarMessage,
 	}


### PR DESCRIPTION
Add sync committee topic handler to decode p2p message and produce TraceEvent.

```
info  | 18:16:50.613902 | Handling sync committee message           
PeerID=16Uiu2HAkuxvJXUaZrQnwTF5NWv28QPYPUMRYiG2HE6uprBMzNfv2 
MsgID=0192365038b3d4e79ef826ee22b30dd9e95c0c98 
MsgSize=146 
Topic=/eth2/d31f6191/sync_committee_3/ssz_snappy 
Seq=[] 
Slot=5005284 
ValIdx=601 
BlockRoot=0x60a1076e48df0b760f621e149b89720e52fd058250d3c5436ad98d5f67c19c82 
Signature=0xb9d46988371bd13d9ca6a1726991491ecd4c684315cf2e151a36afcc8e641a06e42e9177680494b28e4969cb3e3fbe70034e180606ef943cbf92e6ce92b71043943ad5ef675b11ab1943b5988291b04cf76e93e16abf4ca39a5cd28a6698c4e3
```