### PR TITLE
Temporary Fix: Unsubscribe to the `voluntary_exits` topic 

### DIFF
--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -377,7 +377,10 @@ func desiredPubSubBaseTopics() []string {
 		p2p.GossipBlockMessage,
 		p2p.GossipAggregateAndProofMessage,
 		p2p.GossipAttestationMessage,
-		p2p.GossipExitMessage,
+		// In relation to https://github.com/probe-lab/hermes/issues/24
+		// we unfortunatelly can't validate the messages (yet)
+		// thus, better not to forward invalid messages
+		//p2p.GossipExitMessage,
 		p2p.GossipAttesterSlashingMessage,
 		p2p.GossipProposerSlashingMessage,
 		p2p.GossipContributionAndProofMessage,


### PR DESCRIPTION
# Decription
Coming from #24 , there seem to be peers in the network broadcasting exit messages from peers that are not active yet.
Thus, it is better to unsubscribe to the `voluntary_exits` topic - as it prevents us from being pruned from the rest of the meshes.