### PR TITLE
Fix subnet composer start from subnet idx 0

### DIFF
--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -443,12 +443,12 @@ func hasSubnets(topic string) (subnets uint64, hasSubnets bool) {
 	}
 }
 
-func (n *NodeConfig) composeEthTopic(base string, encoder encoder.NetworkEncoding, subnet uint64) string {
-	if subnet > 0 { // as far as I know, there aren't subnets with index 0
-		return fmt.Sprintf(base, n.ForkDigest, subnet) + encoder.ProtocolSuffix()
-	} else {
+func (n *NodeConfig) composeEthTopic(base string, encoder encoder.NetworkEncoding) string {
 		return fmt.Sprintf(base, n.ForkDigest) + encoder.ProtocolSuffix()
 	}
+
+func (n *NodeConfig) composeEthTopicWithSubnet(base string, encoder encoder.NetworkEncoding, subnet uint64) string {
+	return fmt.Sprintf(base, n.ForkDigest, subnet) + encoder.ProtocolSuffix()
 }
 
 func (n *NodeConfig) getDesiredFullTopics(encoder encoder.NetworkEncoding) []string {
@@ -463,11 +463,11 @@ func (n *NodeConfig) getDesiredFullTopics(encoder encoder.NetworkEncoding) []str
 		}
 		subnets, withSubnets := hasSubnets(topicBase)
 		if withSubnets {
-			for subnet := uint64(1); subnet <= subnets; subnet++ {
-				fullTopics = append(fullTopics, n.composeEthTopic(topicFormat, encoder, subnet))
+			for subnet := uint64(0); subnet < subnets; subnet++ {
+				fullTopics = append(fullTopics, n.composeEthTopicWithSubnet(topicFormat, encoder, subnet))
 			}
 		} else {
-			fullTopics = append(fullTopics, n.composeEthTopic(topicFormat, encoder, 0))
+			fullTopics = append(fullTopics, n.composeEthTopic(topicFormat, encoder))
 		}
 	}
 

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -374,18 +374,18 @@ func pubsubGossipParam() pubsub.GossipSubParams {
 // desiredPubSubBaseTopics returns the list of gossip_topics we want to subscribe to
 func desiredPubSubBaseTopics() []string {
 	return []string{
-		p2p.GossipBlockMessage,
-		p2p.GossipAggregateAndProofMessage,
-		p2p.GossipAttestationMessage,
+		// p2p.GossipBlockMessage,
+		// p2p.GossipAggregateAndProofMessage,
+		// p2p.GossipAttestationMessage,
 		// In relation to https://github.com/probe-lab/hermes/issues/24
 		// we unfortunatelly can't validate the messages (yet)
 		// thus, better not to forward invalid messages
-		//p2p.GossipExitMessage,
-		p2p.GossipAttesterSlashingMessage,
-		p2p.GossipProposerSlashingMessage,
-		p2p.GossipContributionAndProofMessage,
-		p2p.GossipSyncCommitteeMessage,
-		p2p.GossipBlsToExecutionChangeMessage,
+		// p2p.GossipExitMessage,
+		// p2p.GossipAttesterSlashingMessage,
+		// p2p.GossipProposerSlashingMessage,
+		// p2p.GossipContributionAndProofMessage,
+		// p2p.GossipSyncCommitteeMessage,
+		// p2p.GossipBlsToExecutionChangeMessage,
 		p2p.GossipBlobSidecarMessage,
 	}
 }
@@ -444,8 +444,8 @@ func hasSubnets(topic string) (subnets uint64, hasSubnets bool) {
 }
 
 func (n *NodeConfig) composeEthTopic(base string, encoder encoder.NetworkEncoding) string {
-		return fmt.Sprintf(base, n.ForkDigest) + encoder.ProtocolSuffix()
-	}
+	return fmt.Sprintf(base, n.ForkDigest) + encoder.ProtocolSuffix()
+}
 
 func (n *NodeConfig) composeEthTopicWithSubnet(base string, encoder encoder.NetworkEncoding, subnet uint64) string {
 	return fmt.Sprintf(base, n.ForkDigest, subnet) + encoder.ProtocolSuffix()


### PR DESCRIPTION
# Description
After generating tedious work to plot the `blob_sidecard` topic-related part of [our blog post](https://probelab.io/blog/deep-dive-dencun/) to participate in the Ethereum [EIP-4844 data challenge](https://esp.ethereum.foundation/data-challenge-4844) , it has been present that we missing 1 subnet when subscribing from [1 .. 6] blob-subnets. 

This PR address it. 

**Solutions:**
- [x] divide the Ethereum topic generator into a plain one and one with subnets
- [x] make subnets starting from `subnet = 0` 