### PR TITLE
feat(eth): add basic authentication support for Prysm client

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ To run Hermes for the Ethereum network you would need to point it to the beacon 
 - `--prysm.port.http=3500` # 3500 is the default
 - `--prysm.port.grpc=4000` # 4000 is the default
 
+If your Prysm node requires basic authentication, you can include the credentials in the host parameter:
+- `--prysm.host=username:password@1.2.3.4`
+
+If your password contains special characters, make sure to URL encode them:
+- `--prysm.host=username:my%40special%3Apass@1.2.3.4` # for password 'my@special:pass'
+
 command line flags to the `hermes ethereum` subcommand. Check out the help page via `hermes ethereum --help` for configuration options of the libp2p host or devp2p local node (e.g., listen addrs/ports).
 
 <details>

--- a/eth/prysm.go
+++ b/eth/prysm.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -12,12 +13,12 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/prysmaticlabs/prysm/v5/api/client"
 	apiCli "github.com/prysmaticlabs/prysm/v5/api/client/beacon"
 	"github.com/prysmaticlabs/prysm/v5/api/server/structs"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/signing"
-
-	"github.com/libp2p/go-libp2p/core/peer"
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/prysmaticlabs/prysm/v5/network/httputil"
 	eth "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"go.opentelemetry.io/otel"
@@ -33,32 +34,80 @@ import (
 type PrysmClient struct {
 	host            string
 	port            int
+	auth            *AuthConfig
 	nodeClient      eth.NodeClient
 	timeout         time.Duration
 	tracer          trace.Tracer
 	beaconClient    eth.BeaconChainClient
 	beaconApiClient *apiCli.Client
 	genesis         *GenesisConfig
+	httpClient      *http.Client
 }
 
 func NewPrysmClient(host string, portHTTP int, portGRPC int, timeout time.Duration, genesis *GenesisConfig) (*PrysmClient, error) {
 	tracer := otel.GetTracerProvider().Tracer("prysm_client")
 
-	conn, err := grpc.NewClient(
-		fmt.Sprintf("%s:%d", host, portGRPC),
+	// Parse any auth info from host we might have.
+	auth, err := parseHostAuth(host)
+	if err != nil {
+		return nil, fmt.Errorf("parse host auth: %w", err)
+	}
+
+	// Setup gRPC options.
+	dialOpts := []grpc.DialOption{
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	}
+
+	// Add auth if credentials provided.
+	if auth.Username != "" && auth.Password != "" {
+		dialOpts = append(dialOpts, grpc.WithPerRPCCredentials(&basicAuthCreds{
+			username: auth.Username,
+			password: auth.Password,
+		}))
+	}
+
+	// Create gRPC client.
+	conn, err := grpc.NewClient(
+		fmt.Sprintf("%s:%d", auth.Host, portGRPC),
+		dialOpts...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new grpc connection: %w", err)
 	}
-	// get connection to HTTP API
-	apiCli, err := apiCli.NewClient(fmt.Sprintf("%s:%d", host, portHTTP))
+
+	// Create API client options.
+	var (
+		opts       = []client.ClientOpt{}
+		httpClient = http.DefaultClient
+	)
+
+	// Add auth transport if credentials provided.
+	if auth.Username != "" && auth.Password != "" {
+		transport := &basicAuthTransport{
+			username: auth.Username,
+			password: auth.Password,
+			base:     http.DefaultTransport,
+		}
+
+		opts = append(opts, client.WithRoundTripper(transport))
+
+		httpClient = &http.Client{
+			Transport: transport,
+		}
+	}
+
+	// Create API client.
+	apiCli, err := apiCli.NewClient(
+		fmt.Sprintf("%s:%d", auth.Host, portHTTP),
+		opts...,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("new http api client: %w", err)
 	}
 
 	return &PrysmClient{
-		host:            host,
+		host:            auth.Host,
+		auth:            auth,
 		port:            portHTTP,
 		nodeClient:      eth.NewNodeClient(conn),
 		beaconClient:    eth.NewBeaconChainClient(conn),
@@ -66,6 +115,7 @@ func NewPrysmClient(host string, portHTTP int, portGRPC int, timeout time.Durati
 		timeout:         timeout,
 		tracer:          tracer,
 		genesis:         genesis,
+		httpClient:      httpClient,
 	}, nil
 }
 
@@ -105,24 +155,14 @@ func (p *PrysmClient) AddTrustedPeer(ctx context.Context, pid peer.ID, maddr ma.
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Length", strconv.Itoa(len(data)))
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("add trusted peer http post failed: %w", err)
 	}
 	defer logDeferErr(resp.Body.Close, "Failed closing body")
 
 	if resp.StatusCode != http.StatusOK {
-		errResp := &httputil.DefaultJsonError{}
-		respData, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed reading response body: %w", err)
-		}
-
-		if err := json.Unmarshal(respData, errResp); err != nil {
-			return fmt.Errorf("failed unmarshalling response data: %w", err)
-		}
-
-		return errResp
+		return parseErrorResponse(resp)
 	}
 
 	return nil
@@ -151,26 +191,16 @@ func (p *PrysmClient) ListTrustedPeers(ctx context.Context) (peers map[peer.ID]*
 	if err != nil {
 		return nil, fmt.Errorf("new list trusted peer request: %w", err)
 	}
-
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("list trusted peer http get failed: %w", err)
 	}
 	defer logDeferErr(resp.Body.Close, "Failed closing body")
 
 	if resp.StatusCode != http.StatusOK {
-		errResp := &httputil.DefaultJsonError{}
-		respData, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("failed reading response body: %w", err)
-		}
-
-		if err := json.Unmarshal(respData, errResp); err != nil {
-			return nil, fmt.Errorf("failed unmarshalling response data: %w", err)
-		}
-
-		return nil, errResp
+		return nil, parseErrorResponse(resp)
 	}
+
 	respData, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("failed reading response body: %w", err)
@@ -217,24 +247,14 @@ func (p *PrysmClient) RemoveTrustedPeer(ctx context.Context, pid peer.ID) (err e
 		return fmt.Errorf("new remove trusted peer request: %w", err)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("remove trusted peer http delete failed: %w", err)
 	}
 	defer logDeferErr(resp.Body.Close, "Failed closing body")
 
 	if resp.StatusCode != http.StatusOK {
-		errResp := &httputil.DefaultJsonError{}
-		respData, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return fmt.Errorf("failed reading response body: %w", err)
-		}
-
-		if err := json.Unmarshal(respData, errResp); err != nil {
-			return fmt.Errorf("failed unmarshalling response data: %w", err)
-		}
-
-		return errResp
+		return parseErrorResponse(resp)
 	}
 
 	return nil
@@ -340,4 +360,24 @@ func (p *PrysmClient) isOnNetwork(ctx context.Context, hermesForkDigest [4]byte)
 		return true, nil
 	}
 	return false, nil
+}
+
+func parseErrorResponse(resp *http.Response) error {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return errors.New("authorization required")
+	default:
+		respData, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed reading response body: %w", err)
+		}
+
+		errResp := &httputil.DefaultJsonError{}
+
+		if err := json.Unmarshal(respData, errResp); err != nil {
+			return fmt.Errorf("failed unmarshalling response data: %w", err)
+		}
+
+		return errResp
+	}
 }

--- a/eth/prysm_auth.go
+++ b/eth/prysm_auth.go
@@ -1,0 +1,80 @@
+package eth
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+// Add new struct to hold auth info
+type AuthConfig struct {
+	Username string
+	Password string
+	Host     string
+}
+
+// Add basic auth transport.
+type basicAuthTransport struct {
+	username string
+	password string
+	base     http.RoundTripper
+}
+
+// Add basic auth credentials for gRPC.
+type basicAuthCreds struct {
+	username string
+	password string
+}
+
+// RoundTrip implements the RoundTripper interface.
+func (t *basicAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.SetBasicAuth(t.username, t.password)
+
+	return t.base.RoundTrip(req)
+}
+
+// GetRequestMetadata returns the request metadata for the basic auth credentials.
+func (b *basicAuthCreds) GetRequestMetadata(context.Context, ...string) (map[string]string, error) {
+	auth := fmt.Sprintf("%s:%s", b.username, b.password)
+
+	return map[string]string{
+		"authorization": fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(auth))),
+	}, nil
+}
+
+// RequireTransportSecurity returns false because we're using HTTP.
+func (b *basicAuthCreds) RequireTransportSecurity() bool {
+	return false
+}
+
+func parseHostAuth(host string) (*AuthConfig, error) {
+	// Parse the authority (user:pass@host) without scheme.
+	u, err := url.Parse("//" + host)
+	if err != nil {
+		return nil, fmt.Errorf("invalid host format: %w", err)
+	}
+
+	auth := &AuthConfig{
+		Host: u.Host,
+	}
+
+	// If we have user info, extract username and password.
+	if u.User != nil {
+		auth.Username = u.User.Username()
+		if pass, ok := u.User.Password(); ok {
+			auth.Password = pass
+		} else if auth.Username != "" {
+			// If we have a username but no password, that's invalid.
+			return nil, fmt.Errorf("invalid auth format: username provided without password")
+		}
+	}
+
+	// If no host was parsed, use the original host string.
+	if auth.Host == "" {
+		auth.Host = host
+	}
+
+	return auth, nil
+}

--- a/eth/prysm_test.go
+++ b/eth/prysm_test.go
@@ -33,24 +33,36 @@ func TestPrysmClient_AddTrustedPeer(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		method         string
+		path           string
+		body           string
 		respStatusCode int
 		respBody       string
 		expectErr      bool
 	}{
 		{
 			name:           "success",
+			method:         http.MethodPost,
+			path:           "/prysm/node/trusted_peers",
+			body:           fmt.Sprintf("%s/p2p/%s", maddr.String(), pid.String()),
 			respStatusCode: http.StatusOK,
 			respBody:       "",
 			expectErr:      false,
 		},
 		{
 			name:           "error_json_unmarshal",
+			method:         http.MethodPost,
+			path:           "/prysm/node/trusted_peers",
+			body:           fmt.Sprintf("%s/p2p/%s", maddr.String(), pid.String()),
 			respStatusCode: http.StatusBadRequest,
 			respBody:       "{invalid_json}",
 			expectErr:      true,
 		},
 		{
 			name:           "invalid_response_status_code",
+			method:         http.MethodPost,
+			path:           "/prysm/node/trusted_peers",
+			body:           fmt.Sprintf("%s/p2p/%s", maddr.String(), pid.String()),
 			respStatusCode: http.StatusBadRequest,
 			respBody:       `{"message": "internal error"}`,
 			expectErr:      true,
@@ -61,8 +73,8 @@ func TestPrysmClient_AddTrustedPeer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Mock HTTP server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodPost, r.Method)
-				assert.Equal(t, "/prysm/node/trusted_peers", r.URL.Path)
+				assert.Equal(t, tt.method, r.Method)
+				assert.Equal(t, tt.path, r.URL.Path)
 
 				data, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
@@ -72,7 +84,7 @@ func TestPrysmClient_AddTrustedPeer(t *testing.T) {
 				err = json.Unmarshal(data, reqData)
 				require.NoError(t, err)
 
-				assert.Equal(t, maddr.String()+"/p2p/"+pid.String(), reqData.Addr)
+				assert.Equal(t, tt.body, reqData.Addr)
 
 				w.WriteHeader(tt.respStatusCode)
 				_, _ = fmt.Fprintln(w, tt.respBody)
@@ -107,24 +119,32 @@ func TestPrysmClient_RemoveTrustedPeer(t *testing.T) {
 
 	tests := []struct {
 		name           string
+		method         string
+		path           string
 		respStatusCode int
 		respBody       string
 		expectErr      bool
 	}{
 		{
 			name:           "success",
+			method:         http.MethodDelete,
+			path:           fmt.Sprintf("/prysm/node/trusted_peers/%s", pid.String()),
 			respStatusCode: http.StatusOK,
 			respBody:       "",
 			expectErr:      false,
 		},
 		{
 			name:           "error_json_unmarshal",
+			method:         http.MethodDelete,
+			path:           fmt.Sprintf("/prysm/node/trusted_peers/%s", pid.String()),
 			respStatusCode: http.StatusBadRequest,
 			respBody:       "{invalid_json}",
 			expectErr:      true,
 		},
 		{
 			name:           "invalid_response_status_code",
+			method:         http.MethodDelete,
+			path:           fmt.Sprintf("/prysm/node/trusted_peers/%s", pid.String()),
 			respStatusCode: http.StatusBadRequest,
 			respBody:       `{"message": "internal error"}`,
 			expectErr:      true,
@@ -135,15 +155,15 @@ func TestPrysmClient_RemoveTrustedPeer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Mock HTTP server
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodDelete, r.Method)
-				assert.Equal(t, "/prysm/node/trusted_peers/"+pid.String(), r.URL.Path)
+				assert.Equal(t, tt.method, r.Method)
+				assert.Equal(t, tt.path, r.URL.Path)
 
 				w.WriteHeader(tt.respStatusCode)
 				_, _ = fmt.Fprintln(w, tt.respBody)
 			}))
 			defer server.Close()
 
-			// Get mocked server URL
+			// Get mocked server URL.
 			serverURL, err := url.Parse(server.URL)
 			require.NoError(t, err)
 
@@ -153,6 +173,270 @@ func TestPrysmClient_RemoveTrustedPeer(t *testing.T) {
 			p, err := NewPrysmClient(serverURL.Hostname(), port, 0, time.Second, nil)
 			require.NoError(t, err)
 
+			err = p.RemoveTrustedPeer(context.Background(), pid)
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseHostAuth(t *testing.T) {
+	tests := []struct {
+		name        string
+		host        string
+		wantHost    string
+		wantUser    string
+		wantPass    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:     "no_auth",
+			host:     "localhost",
+			wantHost: "localhost",
+		},
+		{
+			name:     "with_auth",
+			host:     "user:pass@localhost",
+			wantHost: "localhost",
+			wantUser: "user",
+			wantPass: "pass",
+		},
+		{
+			name:     "with_special_chars_in_pass",
+			host:     "user:p%40ss%3A123@localhost",
+			wantHost: "localhost",
+			wantUser: "user",
+			wantPass: "p@ss:123",
+		},
+		{
+			name:        "invalid_auth_format",
+			host:        "user@localhost",
+			wantErr:     true,
+			errContains: "invalid auth format",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			auth, err := parseHostAuth(tt.host)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errContains)
+
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, auth.Host)
+			assert.Equal(t, tt.wantUser, auth.Username)
+			assert.Equal(t, tt.wantPass, auth.Password)
+		})
+	}
+}
+
+func TestPrysmClient_AuthenticatedRequests(t *testing.T) {
+	otel.SetTracerProvider(tele.NoopTracerProvider())
+
+	maddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/1234")
+	require.NoError(t, err)
+
+	pid, err := peer.Decode("16Uiu2HAmBBTgCRezbBY8LbdfDN5PXYi3C1hwdoXJ9DZAorsWs4NR")
+	require.NoError(t, err)
+
+	type request struct {
+		method string
+		path   string
+		body   string // empty for GET/DELETE
+	}
+
+	type testCredentials struct {
+		username string
+		password string
+	}
+
+	tests := []struct {
+		name           string
+		host           string
+		checkAuth      bool
+		credentials    testCredentials
+		respStatusCode int
+		expectErr      bool
+		requests       []request
+	}{
+		{
+			name:           "no_auth_success",
+			host:           "localhost",
+			checkAuth:      false,
+			respStatusCode: http.StatusOK,
+			expectErr:      false,
+			requests: []request{
+				{
+					method: http.MethodPost,
+					path:   "/prysm/node/trusted_peers",
+					body:   fmt.Sprintf("%s/p2p/%s", maddr.String(), pid.String()),
+				},
+				{
+					method: http.MethodGet,
+					path:   "/prysm/node/trusted_peers",
+				},
+				{
+					method: http.MethodDelete,
+					path:   fmt.Sprintf("/prysm/node/trusted_peers/%s", pid.String()),
+				},
+			},
+		},
+		{
+			name:      "with_auth_success",
+			host:      "testuser:testpass@localhost",
+			checkAuth: true,
+			credentials: testCredentials{
+				username: "testuser",
+				password: "testpass",
+			},
+			respStatusCode: http.StatusOK,
+			expectErr:      false,
+			requests: []request{
+				{
+					method: http.MethodPost,
+					path:   "/prysm/node/trusted_peers",
+					body:   fmt.Sprintf("%s/p2p/%s", maddr.String(), pid.String()),
+				},
+				{
+					method: http.MethodGet,
+					path:   "/prysm/node/trusted_peers",
+				},
+				{
+					method: http.MethodDelete,
+					path:   fmt.Sprintf("/prysm/node/trusted_peers/%s", pid.String()),
+				},
+			},
+		},
+		{
+			name:      "with_auth_special_chars",
+			host:      "testuser:test%40pass%3A123@localhost",
+			checkAuth: true,
+			credentials: testCredentials{
+				username: "testuser",
+				password: "test@pass:123",
+			},
+			respStatusCode: http.StatusOK,
+			expectErr:      false,
+			requests: []request{
+				{
+					method: http.MethodPost,
+					path:   "/prysm/node/trusted_peers",
+					body:   fmt.Sprintf("%s/p2p/%s", maddr.String(), pid.String()),
+				},
+				{
+					method: http.MethodGet,
+					path:   "/prysm/node/trusted_peers",
+				},
+				{
+					method: http.MethodDelete,
+					path:   fmt.Sprintf("/prysm/node/trusted_peers/%s", pid.String()),
+				},
+			},
+		},
+		{
+			name:      "with_auth_unauthorized",
+			host:      "testuser:wrongpass@localhost",
+			checkAuth: true,
+			credentials: testCredentials{
+				username: "testuser",
+				password: "testpass",
+			},
+			respStatusCode: http.StatusUnauthorized,
+			expectErr:      true,
+			requests: []request{
+				{
+					method: http.MethodPost,
+					path:   "/prysm/node/trusted_peers",
+					body:   fmt.Sprintf("%s/p2p/%s", maddr.String(), pid.String()),
+				},
+				{
+					method: http.MethodGet,
+					path:   "/prysm/node/trusted_peers",
+				},
+				{
+					method: http.MethodDelete,
+					path:   fmt.Sprintf("/prysm/node/trusted_peers/%s", pid.String()),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock HTTP server that checks auth.
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				// Check auth if required.
+				if tt.checkAuth {
+					user, pass, ok := r.BasicAuth()
+					if !ok || user != tt.credentials.username || pass != tt.credentials.password {
+						w.WriteHeader(http.StatusUnauthorized)
+
+						return
+					}
+				}
+
+				// Find matching request.
+				var matchedReq *request
+				for _, req := range tt.requests {
+					if req.method == r.Method && req.path == r.URL.Path {
+						matchedReq = &req
+
+						break
+					}
+				}
+
+				if matchedReq == nil {
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+					w.WriteHeader(http.StatusNotFound)
+
+					return
+				}
+
+				// Just return status code - we're only testing auth.
+				w.WriteHeader(tt.respStatusCode)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte("{}"))
+			}))
+			defer server.Close()
+
+			// Get mocked server URL.
+			serverURL, err := url.Parse(server.URL)
+			require.NoError(t, err)
+
+			port, err := strconv.Atoi(serverURL.Port())
+			require.NoError(t, err)
+
+			// Create client with the test host (which may include auth).
+			p, err := NewPrysmClient(tt.host, port, 0, time.Second, nil)
+			require.NoError(t, err)
+
+			// Test AddTrustedPeer with auth.
+			err = p.AddTrustedPeer(context.Background(), pid, maddr)
+			if tt.expectErr {
+				assert.Error(t, err)
+				if tt.respStatusCode == http.StatusUnauthorized {
+					assert.Contains(t, err.Error(), "authorization required")
+				}
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Test ListTrustedPeers with auth.
+			_, err = p.ListTrustedPeers(context.Background())
+			if tt.expectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			// Test RemoveTrustedPeer with auth.
 			err = p.RemoveTrustedPeer(context.Background(), pid)
 			if tt.expectErr {
 				assert.Error(t, err)


### PR DESCRIPTION
This commit introduces basic authentication support for the Prysm client, allowing users to connect to Prysm nodes that require authentication.

Our main driver for this addition is so we can expose the closest prysm instances we run (across differing regions) via the internet with basic auth as the upstream to our application that is backed by Hermes.

The following changes were made:

- Added a new `AuthConfig` struct to hold authentication information (username, password, and host).
- Added a `parseHostAuth` function to parse the host string and extract authentication information.
- Added `basicAuthTransport` and `basicAuthCreds` structs to handle HTTP and gRPC basic authentication, respectively.
- Modified the `NewPrysmClient` function to parse authentication information from the host string and configure the HTTP and gRPC clients accordingly.
- Updated the `AddTrustedPeer`, `ListTrustedPeers`, and `RemoveTrustedPeer` functions to use the HTTP client configured with authentication.
- Added a `parseErrorResponse` function to handle error responses from the Prysm node.
- Added new tests to verify the authentication functionality.



