### PR TITLE
feat(cmd): add TLS support for Prysm client

### DIFF
--- a/cmd/hermes/cmd_eth.go
+++ b/cmd/hermes/cmd_eth.go
@@ -33,6 +33,7 @@ var ethConfig = &struct {
 	PrysmHost                   string
 	PrysmPortHTTP               int
 	PrysmPortGRPC               int
+	PrysmUseTLS                 bool
 	DialConcurrency             int
 	DialTimeout                 time.Duration
 	MaxPeers                    int
@@ -69,6 +70,7 @@ var ethConfig = &struct {
 	PrysmHost:                   "",
 	PrysmPortHTTP:               3500, // default -> https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip
 	PrysmPortGRPC:               4000, // default -> https://docs.prylabs.network/docs/prysm-usage/p2p-host-ip
+	PrysmUseTLS:                 false,
 	DialConcurrency:             16,
 	DialTimeout:                 5 * time.Second,
 	MaxPeers:                    30, // arbitrary
@@ -211,6 +213,13 @@ var cmdEthFlags = []cli.Flag{
 		Usage:       "The port on which Prysm's gRPC API is listening on",
 		Value:       ethConfig.PrysmPortGRPC,
 		Destination: &ethConfig.PrysmPortGRPC,
+	},
+	&cli.BoolFlag{
+		Name:        "prysm.tls",
+		EnvVars:     []string{"HERMES_ETH_PRYSM_USE_TLS"},
+		Usage:       "Whether to use TLS when connecting to Prysm",
+		Value:       ethConfig.PrysmUseTLS,
+		Destination: &ethConfig.PrysmUseTLS,
 	},
 	&cli.IntFlag{
 		Name:        "max-peers",
@@ -442,6 +451,7 @@ func cmdEthAction(c *cli.Context) error {
 		PrysmHost:                   ethConfig.PrysmHost,
 		PrysmPortHTTP:               ethConfig.PrysmPortHTTP,
 		PrysmPortGRPC:               ethConfig.PrysmPortGRPC,
+		PrysmUseTLS:                 ethConfig.PrysmUseTLS,
 		DataStreamType:              host.DataStreamtypeFromStr(rootConfig.DataStreamType),
 		AWSConfig:                   rootConfig.awsConfig,
 		S3Config:                    rootConfig.s3Config,

--- a/eth/node.go
+++ b/eth/node.go
@@ -202,9 +202,9 @@ func NewNode(cfg *NodeConfig) (*Node, error) {
 	}
 
 	// initialize the custom Prysm client to communicate with its API
-	pryClient, err := NewPrysmClient(cfg.PrysmHost, cfg.PrysmPortHTTP, cfg.PrysmPortGRPC, cfg.DialTimeout, cfg.GenesisConfig)
+	pryClient, err := NewPrysmClientWithTLS(cfg.PrysmHost, cfg.PrysmPortHTTP, cfg.PrysmPortGRPC, cfg.PrysmUseTLS, cfg.DialTimeout, cfg.GenesisConfig)
 	if err != nil {
-		return nil, fmt.Errorf("new prysm client")
+		return nil, fmt.Errorf("new prysm client: %w", err)
 	}
 	// check if Prysm is valid
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -75,6 +75,7 @@ type NodeConfig struct {
 	PrysmHost        string
 	PrysmPortHTTP    int
 	PrysmPortGRPC    int
+	PrysmUseTLS      bool
 
 	// The Data Stream configuration
 	DataStreamType host.DataStreamType


### PR DESCRIPTION
This commit introduces functionality to allow users to configure Hermes to connect to Prysm nodes using TLS.

The following changes were made:

- Added a `PrysmUseTLS` field to the `ethConfig` struct in `cmd/hermes/cmd_eth.go` to enable/disable TLS.
- Added a `--prysm.tls` flag to the `cmdEthFlags` array in `cmd/hermes/cmd_eth.go` to control the TLS setting via the CLI.
- Modified the `cmdEthAction` function in `cmd/hermes/cmd_eth.go` to pass the `PrysmUseTLS` value to the `NewNode` function.
- Added a `PrysmUseTLS` field to the `NodeConfig` struct in `eth/node_config.go`.
- Modified the `NewNode` function in `eth/node.go` to pass the `PrysmUseTLS` value to the `NewPrysmClientWithTLS` function.
- Added a `NewPrysmClientWithTLS` function in `eth/prysm.go` that accepts a `useTLS` parameter.
- Modified the `NewPrysmClient` function in `eth/prysm.go` to call `NewPrysmClientWithTLS` with `useTLS` set to `false`.
- Updated the `AddTrustedPeer`, `ListTrustedPeers`, and `RemoveTrustedPeer` functions in `eth/prysm.go` to use the correct scheme (HTTP or HTTPS) based on the `useTLS` setting.
- Added tests for the TLS functionality in `eth/prysm_test.go`.