### PR TITLE
feat(eth): add support for subscribing to custom topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ network.
   - [Deployment](#deployment)
     - [General](#general)
     - [Ethereum](#ethereum)
+      - [Subnet Configuration](#subnet-configuration)
+      - [Topic Subscription](#topic-subscription)
   - [Telemetry](#telemetry)
     - [Metrics](#metrics)
     - [Tracing](#tracing)
@@ -229,7 +231,28 @@ For each topic that supports subnets, you can use one of these configuration str
    }
    ```
 
-This configuration allows you to set up multiple Hermes instances that monitor different parts of the network, or to focus monitoring on specific subnets of interest.
+#### Topic Subscription
+
+In addition to subnet configuration, Hermes allows you to specify exactly which topics to subscribe to using the `--subscription.topics` flag. This gives you fine-grained control over which message types Hermes will monitor.
+
+By default, Hermes subscribes to all standard topics:
+- Block messages
+- Aggregate and proof messages
+- Attestation messages
+- Attester slashing messages
+- Proposer slashing messages
+- Contribution and proof messages
+- Sync committee messages
+- BLS to execution change messages
+- Blob sidecar messages
+
+To subscribe to only specific topics, use the `--subscription.topics` flag with a comma-separated list:
+
+```shell
+hermes eth --subscription.topics="beacon_attestation,beacon_block"
+```
+
+This configuration allows you to set up multiple Hermes instances that monitor different parts of the network, or to focus monitoring on specific subnets and topics of interest.
 
 To run Hermes for the Ethereum network you would need to point it to the beacon node by providing the
 
@@ -282,6 +305,7 @@ OPTIONS:
    --config.yaml.url value                                                        The .yaml URL from which to fetch the beacon chain config, requires 'chain=devnet' [$HERMES_ETH_CONFIG_URL]
    --bootnodes.yaml.url value                                                     The .yaml URL from which to fetch the bootnode ENRs, requires 'chain=devnet' [$HERMES_ETH_BOOTNODES_URL]
    --deposit-contract-block.txt.url value                                         The .txt URL from which to fetch the deposit contract block. Requires 'chain=devnet' [$HERMES_ETH_DEPOSIT_CONTRACT_BLOCK_URL]
+   --subscription.topics value [ --subscription.topics value ]                    Comma-separated list of topics to subscribe to (e.g. beacon_attestation,beacon_block) [$HERMES_ETH_SUBSCRIPTION_TOPICS]
    --subnet.attestation.type value                                                Subnet selection strategy for attestation topics (all, static, random, static_range) (default: "all") [$HERMES_ETH_SUBNET_ATTESTATION_TYPE]
    --subnet.attestation.subnets value [ --subnet.attestation.subnets value ]      Comma-separated list of subnet IDs for attestation when type=static [$HERMES_ETH_SUBNET_ATTESTATION_SUBNETS]
    --subnet.attestation.count value                                               Number of random attestation subnets to select when type=random (default: 0) [$HERMES_ETH_SUBNET_ATTESTATION_COUNT]

--- a/cmd/hermes/cmd_eth.go
+++ b/cmd/hermes/cmd_eth.go
@@ -57,6 +57,7 @@ var ethConfig = &struct {
 	SubnetBlobSidecarCount     uint64
 	SubnetBlobSidecarStart     uint64
 	SubnetBlobSidecarEnd       uint64
+	SubscriptionTopics         []string
 }{
 	PrivateKeyStr:               "", // unset means it'll be generated
 	Chain:                       params.MainnetName,
@@ -370,6 +371,15 @@ var cmdEthFlags = []cli.Flag{
 		Value:       ethConfig.SubnetBlobSidecarEnd,
 		Destination: &ethConfig.SubnetBlobSidecarEnd,
 	},
+	&cli.StringSliceFlag{
+		Name:    "subscription.topics",
+		EnvVars: []string{"HERMES_ETH_SUBSCRIPTION_TOPICS"},
+		Usage:   "An optional comma-separated list of topics to subscribe to",
+		Action: func(c *cli.Context, v []string) error {
+			ethConfig.SubscriptionTopics = v
+			return nil
+		},
+	},
 }
 
 func cmdEthAction(c *cli.Context) error {
@@ -463,6 +473,7 @@ func cmdEthAction(c *cli.Context) error {
 		PubSubSubscriptionRequestLimit: 200, // Prysm: beacon-chain/p2p/pubsub_filter.go#L22
 		PubSubQueueSize:                600, // Prysm: beacon-chain/p2p/config.go#L10
 		SubnetConfigs:                  createSubnetConfigs(),
+		SubscriptionTopics:             ethConfig.SubscriptionTopics,
 		Tracer:                         otel.GetTracerProvider().Tracer("hermes"),
 		Meter:                          otel.GetMeterProvider().Meter("hermes"),
 	}

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"math"
 	"net"
+	"strings"
 	"time"
 
 	"github.com/OffchainLabs/prysm/v6/beacon-chain/p2p"
@@ -105,6 +106,10 @@ type NodeConfig struct {
 	// Configuration for subnet selection by topic
 	SubnetConfigs map[string]*SubnetConfig
 
+	// SubscriptionTopics is a list of topics to subscribe to. If not set,
+	// the default list of topics will be used.
+	SubscriptionTopics []string
+
 	// Telemetry accessors
 	Tracer trace.Tracer
 	Meter  metric.Meter
@@ -179,6 +184,19 @@ func (n *NodeConfig) Validate() error {
 
 			// Validate the subnet config for this topic.
 			if err := config.Validate(topic, subnetCount); err != nil {
+				return err
+			}
+		}
+	}
+
+	// Validate the SubscriptionTopics if provided.
+	if n.SubscriptionTopics != nil {
+		for _, topicBase := range n.SubscriptionTopics {
+			if topicBase == "" {
+				return fmt.Errorf("empty gossipsub topic provided")
+			}
+
+			if _, err := topicFormatFromBase(topicBase); err != nil {
 				return err
 			}
 		}
@@ -471,8 +489,17 @@ func (n *NodeConfig) composeEthTopicWithSubnet(base string, encoder encoder.Netw
 }
 
 func (n *NodeConfig) getDesiredFullTopics(encoder encoder.NetworkEncoding) []string {
-	desiredTopics := desiredPubSubBaseTopics()
-	fullTopics := make([]string, 0)
+	var (
+		desiredTopics = desiredPubSubBaseTopics()
+		fullTopics    = make([]string, 0)
+	)
+
+	// If the user has specified a list of topics to subscribe to, use that instead of the default list.
+	if n.SubscriptionTopics != nil && len(n.SubscriptionTopics) > 0 {
+		desiredTopics = n.SubscriptionTopics
+
+		slog.Info("Using user-specified topics", slog.Attr{Key: "topics", Value: slog.StringValue(strings.Join(desiredTopics, ", "))})
+	}
 
 	for _, topicBase := range desiredTopics {
 		topicFormat, err := topicFormatFromBase(topicBase)

--- a/eth/node_config.go
+++ b/eth/node_config.go
@@ -495,7 +495,7 @@ func (n *NodeConfig) getDesiredFullTopics(encoder encoder.NetworkEncoding) []str
 	)
 
 	// If the user has specified a list of topics to subscribe to, use that instead of the default list.
-	if n.SubscriptionTopics != nil && len(n.SubscriptionTopics) > 0 {
+	if len(n.SubscriptionTopics) > 0 {
 		desiredTopics = n.SubscriptionTopics
 
 		slog.Info("Using user-specified topics", slog.Attr{Key: "topics", Value: slog.StringValue(strings.Join(desiredTopics, ", "))})

--- a/eth/node_config_test.go
+++ b/eth/node_config_test.go
@@ -76,9 +76,10 @@ func TestNodeConfig_ValidateSubnetConfigs(t *testing.T) {
 func TestNodeConfig_GetDesiredFullTopics(t *testing.T) {
 	ssz := encoder.SszNetworkEncoder{}
 	tests := []struct {
-		name           string
-		subnetConfigs  map[string]*SubnetConfig
-		wantTopicsFunc func(t *testing.T, topics []string)
+		name               string
+		subnetConfigs      map[string]*SubnetConfig
+		subscriptionTopics []string
+		wantTopicsFunc     func(t *testing.T, topics []string)
 	}{
 		{
 			name: "static subnet config",
@@ -141,12 +142,52 @@ func TestNodeConfig_GetDesiredFullTopics(t *testing.T) {
 				)
 			},
 		},
+		{
+			name: "custom subscription topics",
+			subscriptionTopics: []string{
+				p2p.GossipBlockMessage,
+				p2p.GossipAttestationMessage,
+			},
+			subnetConfigs: map[string]*SubnetConfig{
+				p2p.GossipAttestationMessage: {
+					Type:    SubnetStatic,
+					Subnets: []uint64{1, 2},
+				},
+			},
+			wantTopicsFunc: func(t *testing.T, topics []string) {
+				// Check that we only have topics for the specified subscription topics
+				blockTopicFormat, err := topicFormatFromBase(p2p.GossipBlockMessage)
+				require.NoError(t, err)
+				blockTopic := fmt.Sprintf(blockTopicFormat, [4]byte{1, 2, 3, 4}) + ssz.ProtocolSuffix()
+
+				attTopicFormat, err := topicFormatFromBase(p2p.GossipAttestationMessage)
+				require.NoError(t, err)
+
+				// Check that block topic is included
+				assert.Contains(t, topics, blockTopic, "Block topic not found in result")
+
+				// Check that attestation subnet topics are included
+				for _, subnet := range []uint64{1, 2} {
+					subnetTopic := formatSubnetTopic(attTopicFormat, subnet, ssz)
+					assert.Contains(t, topics, subnetTopic, "Expected subnet topic not found in result")
+				}
+
+				// Check that we don't have any other base topics
+				// For example, we shouldn't have aggregate and proof messages
+				aggAndProofTopicFormat, err := topicFormatFromBase(p2p.GossipAggregateAndProofMessage)
+				require.NoError(t, err)
+				aggAndProofTopic := fmt.Sprintf(aggAndProofTopicFormat, [4]byte{1, 2, 3, 4}) + ssz.ProtocolSuffix()
+
+				assert.NotContains(t, topics, aggAndProofTopic, "Unexpected topic found in result")
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := setupTestNodeConfig()
 			cfg.SubnetConfigs = tt.subnetConfigs
+			cfg.SubscriptionTopics = tt.subscriptionTopics
 
 			topics := cfg.getDesiredFullTopics(ssz)
 			tt.wantTopicsFunc(t, topics)


### PR DESCRIPTION
This commit adds a new flag `--subscription.topics` to the `eth` command, which allows users to specify a comma-separated list of topics to subscribe to. If this flag is not set, the default list of topics will be used.

This PR is a natural extension of https://github.com/probe-lab/hermes/pull/51 and is useful for users who only want to subscribe to a subset of topics, which can reduce the amount of data they receive and improve performance.

At the moment, ethPandaOps are running a slightly modified version of Hermes for probe-lab (reduced topic subscriptions, etc), utilising the S3 producer and sending the data to their bucket. The addition of this PR would remove the need to modify Hermes for this use-case, allow us to target `main` and configure these topics as needed.

**Example usage:**

```
go run ./cmd/hermes --data.stream.type=logger eth --chain=mainnet --prysm.host=X --prysm.port.http=X --prysm.port.grpc=X --subscription.topics=beacon_attestation,beacon_block
```