### PR TITLE
feat(eth/reqresp): Add metric for received goodbye messages

### DIFF
--- a/eth/reqresp.go
+++ b/eth/reqresp.go
@@ -69,6 +69,7 @@ type ReqResp struct {
 	// metrics
 	meterRequestCounter metric.Int64Counter
 	latencyHistogram    metric.Float64Histogram
+	goodbyeCounter      metric.Int64Counter
 }
 
 type ContextStreamHandler func(context.Context, network.Stream) (map[string]any, error)
@@ -108,6 +109,14 @@ func NewReqResp(h host.Host, cfg *ReqRespConfig) (*ReqResp, error) {
 	)
 	if err != nil {
 		return nil, fmt.Errorf("new request_latency histogram: %w", err)
+	}
+
+	p.goodbyeCounter, err = cfg.Meter.Int64Counter(
+		"goodbye_messages",
+		metric.WithDescription("Counter for goodbye messages received"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("new goodbye_messages counter: %w", err)
 	}
 
 	return p, nil
@@ -228,7 +237,7 @@ func (r *ReqResp) wrapStreamHandler(ctx context.Context, name string, handler Co
 		agentVersion := "n.a."
 		if err == nil {
 			if av, ok := rawVal.(string); ok {
-				agentVersion = av
+				agentVersion = normalizeAgentVersion(av)
 			}
 		}
 
@@ -324,6 +333,32 @@ func (r *ReqResp) goodbyeHandler(ctx context.Context, stream network.Stream) (ma
 	msg, found := types.GoodbyeCodeMessages[req]
 	if found {
 		if _, err := r.host.Peerstore().Get(stream.Conn().RemotePeer(), peerstoreKeyIsHandshaked); err == nil {
+			var (
+				agentVersion = "unknown"
+				reason       = "unknown"
+			)
+
+			// Get agent version (client) for the peer.
+			rawVal, err := r.host.Peerstore().Get(stream.Conn().RemotePeer(), "AgentVersion")
+			if err == nil {
+				if av, ok := rawVal.(string); ok {
+					agentVersion = normalizeAgentVersion(av)
+				}
+			}
+
+			// This will be one of GoodbyeCodeMessages.
+			if found {
+				reason = msg
+			}
+
+			r.goodbyeCounter.Add(ctx, 1, metric.WithAttributes(
+				[]attribute.KeyValue{
+					attribute.Int64("code", int64(req)),
+					attribute.String("reason", reason),
+					attribute.String("agent", agentVersion),
+				}...,
+			))
+
 			slog.Info("Received goodbye message", tele.LogAttrPeerID(stream.Conn().RemotePeer()), "msg", msg)
 		} else {
 			slog.Debug("Received goodbye message", tele.LogAttrPeerID(stream.Conn().RemotePeer()), "msg", msg)
@@ -1079,4 +1114,31 @@ func (r *ReqResp) getBlockForForkVersion(forkV ForkVersion, encoding encoder.Net
 		sblk, _ := blocks.NewSignedBeaconBlock(&pb.SignedBeaconBlock{})
 		return sblk, fmt.Errorf("unrecognized fork_version (received:%s) (ours: %s) (global: %s)", forkV, r.cfg.ForkDigest, DenebForkVersion)
 	}
+}
+
+// normalizeAgentVersion extracts the client name from the agent version string
+// to reduce metric cardinality.
+func normalizeAgentVersion(agentVersion string) string {
+	// List of known consensus layer clients
+	knownClients := []string{
+		"prysm", "lighthouse", "nimbus", "lodestar", "grandine", "teku", "erigon", "caplin",
+	}
+
+	// Convert to lowercase for case-insensitive matching.
+	lowerAgent := strings.ToLower(agentVersion)
+
+	// Try to match against known clients.
+	for _, client := range knownClients {
+		if strings.Contains(lowerAgent, client) {
+			return client
+		}
+	}
+
+	// Extract first part before slash if present.
+	parts := strings.Split(lowerAgent, "/")
+	if len(parts) > 0 && parts[0] != "" {
+		return parts[0]
+	}
+
+	return "unknown"
 }


### PR DESCRIPTION
Add a counter to track goodbye messages received from peers.

This metric includes attributes for the goodbye code, the reason string, and the peer's agent version. This provides visibility into why peers are disconnecting.

Introduce a helper function `normalizeAgentVersion` to extract the client name from the agent version string. This reduces the cardinality of the agent attribute in the metric.

Also apply `normalizeAgentVersion` to the agent version logged in the stream handler for consistency.

```
# HELP hermes_goodbye_messages_total Counter for goodbye messages received
# TYPE hermes_goodbye_messages_total counter
hermes_goodbye_messages_total{agent="lighthouse",code="129",otel_scope_name="hermes",otel_scope_version="",reason="client has too many peers"} 1
```